### PR TITLE
Add support for Subkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Paradex Python SDK provides a simple interface to interact with the Paradex REST
 
 ## Examples
 
+### L1 + L2 Authentication (Traditional)
+
 ```python
 from paradex_py import Paradex
 from paradex_py.environment import Environment
@@ -18,9 +20,24 @@ paradex = Paradex(env=Environment.TESTNET, l1_address="0x...", l1_private_key="0
 print(hex(paradex.account.l2_address)) # 0x...
 print(hex(paradex.account.l2_public_key)) # 0x...
 print(hex(paradex.account.l2_private_key)) # 0x...
+```
 
-paradex.api_client.fetch_system_config() # { ..., "paraclear_decimals": 8, ... }
+### L2-Only Authentication (Subkey)
 
+```python
+from paradex_py import Paradex
+from paradex_py.environment import Environment
+
+# Use only L2 private key - no L1 address needed
+paradex = Paradex(env=Environment.TESTNET, l2_private_key="0x...", l2_address="0x...")
+print(hex(paradex.account.l2_address)) # 0x...
+print(hex(paradex.account.l2_public_key)) # 0x...
+print(hex(paradex.account.l2_private_key)) # 0x...
+```
+
+### WebSocket Usage
+
+```python
 async def on_message(ws_channel, message):
     print(ws_channel, message)
 
@@ -32,7 +49,8 @@ await paradex.ws_client.subscribe(ParadexWebsocketChannel.MARKETS_SUMMARY, callb
 
 💻 For comprehensive examples refer to following files:
 
-- API: [examples/call_rest_api.py](examples/call_rest_api.py)
+- API (L1+L2): [examples/call_rest_api.py](examples/call_rest_api.py)
+- API (L2-only): [examples/subkey_rest_api.py](examples/subkey_rest_api.py)
 - WS: [examples/connect_ws_api.py](examples/connect_ws_api.py)
 - Transfer: [examples/transfer_l2_usdc.py](examples/transfer_l2_usdc.py)
 

--- a/examples/subkey_rest_api.py
+++ b/examples/subkey_rest_api.py
@@ -1,0 +1,204 @@
+import os
+import time
+from datetime import datetime
+from decimal import Decimal
+
+from paradex_py import Paradex
+from paradex_py.common.order import Order, OrderSide, OrderType
+from paradex_py.environment import TESTNET
+
+# Environment variables
+TEST_L2_PRIVATE_KEY = os.getenv("L2_PRIVATE_KEY", "")
+TEST_L2_ADDRESS = os.getenv("L2_ADDRESS", "")
+LOG_FILE = os.getenv("LOG_FILE", "FALSE").lower() == "true"
+
+if LOG_FILE:
+    from paradex_py.common.file_logging import file_logger
+
+    logger = file_logger
+    logger.info("Using file logger")
+else:
+    from paradex_py.common.console_logging import console_logger
+
+    logger = console_logger
+    logger.info("Using console logger")
+
+# Fetch markets data for the example
+public_paradex = Paradex(env=TESTNET, logger=logger)
+markets = public_paradex.api_client.fetch_markets()
+logger.info(f"{markets=}")
+
+# Test Private API calls using L2-only authentication with a subkey
+paradex = Paradex(
+    env=TESTNET,
+    l2_private_key=TEST_L2_PRIVATE_KEY,
+    l2_address=TEST_L2_ADDRESS,
+    logger=logger,
+)
+account_summary = paradex.api_client.fetch_account_summary()
+logger.info(f"{account_summary=}")
+account_profile = paradex.api_client.fetch_account_profile()
+logger.info(f"{account_profile=}")
+
+balances = paradex.api_client.fetch_balances()
+logger.info(f"{balances=}")
+positions = paradex.api_client.fetch_positions()
+logger.info(f"{positions=}")
+try:
+    transactions = paradex.api_client.fetch_transactions(params={"page_size": 5})
+    logger.info(f"{transactions=}")
+except Exception as e:
+    logger.warning(f"Failed to fetch transactions (timeout): {e}")
+    transactions = {"results": [], "error": "timeout"}
+try:
+    fills = paradex.api_client.fetch_fills(params={"page_size": 5})
+    logger.info(f"{fills=}")
+except Exception as e:
+    logger.warning(f"Failed to fetch fills (timeout): {e}")
+    fills = {"results": [], "error": "timeout"}
+
+try:
+    tradebusts = paradex.api_client.fetch_tradebusts()
+    logger.info(f"{tradebusts=}")
+except Exception as e:
+    logger.warning(f"Failed to fetch tradebusts (timeout): {e}")
+    tradebusts = {"results": [], "error": "timeout"}
+
+try:
+    hist_orders = paradex.api_client.fetch_orders_history(params={"page_size": 5})
+    logger.info(f"{hist_orders=}")
+except Exception as e:
+    logger.warning(f"Failed to fetch orders history (timeout): {e}")
+    hist_orders = {"results": [], "error": "timeout"}
+subaccounts = paradex.api_client.fetch_subaccounts()
+logger.info(f"{subaccounts=}")
+account_info = paradex.api_client.fetch_account_info()
+logger.info(f"{account_info=}")
+
+
+points_program = paradex.api_client.fetch_points_data(
+    market="ETH-USD-PERP",
+    program="Maker",
+)
+logger.info(f"Maker {points_program=}")
+
+transfers = paradex.api_client.fetch_transfers(params={"page_size": 5})
+logger.info(f"{transfers=}")
+# Per market
+for market in markets["results"][:5]:  # Limit to 5 markets for testing
+    if not int(market.get("position_limit")):
+        continue
+    symbol = market["symbol"]
+    orders = paradex.api_client.fetch_orders(params={"market": symbol})
+    logger.info(f"{symbol=} {orders=}")
+    fills = paradex.api_client.fetch_fills(params={"market": symbol, "page_size": 5})
+    logger.info(f"{symbol=} {fills=}")
+    funding_payments = paradex.api_client.fetch_funding_payments(params={"market": symbol})
+    logger.info(f"{symbol=} {funding_payments=}")
+
+
+# Create Order object and submit order
+buy_client_id = f"test_buy_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+buy_order = Order(
+    market="BTC-USD-PERP",
+    order_type=OrderType.Limit,
+    order_side=OrderSide.Buy,
+    size=Decimal("0.01"),
+    limit_price=Decimal(11_500),
+    client_id=buy_client_id,
+    instruction="POST_ONLY",
+    reduce_only=False,
+)
+response = paradex.api_client.submit_order(order=buy_order)
+buy_id = response.get("id")
+logger.info(f"Buy Order {response=}")
+if buy_id is None:
+    logger.error("Failed to get buy order ID")
+    exit(1)
+buy_order_status = paradex.api_client.fetch_order_by_client_id(client_id=buy_client_id)
+logger.info(f"{buy_order_status=}")
+
+# Sell order
+sell_client_id = f"test_sell_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+sell_order = Order(
+    market="ETH-USD-PERP",
+    order_type=OrderType.Limit,
+    order_side=OrderSide.Sell,
+    size=Decimal("0.1"),
+    limit_price=Decimal(5_500),
+    client_id=sell_client_id,
+    instruction="POST_ONLY",
+    reduce_only=False,
+)
+response = paradex.api_client.submit_order(order=sell_order)
+logger.info(f"Sell Order {response=}")
+sell_id = response.get("id")
+if sell_id is None:
+    logger.error("Failed to get sell order ID")
+    exit(1)
+sell_order_status = paradex.api_client.fetch_order(order_id=sell_id)
+logger.info(f"{sell_order_status=}")
+
+# Check all open orders
+orders = paradex.api_client.fetch_orders()
+logger.info(f"ALL {orders=}")
+logger.info("Sleeping for 3 seconds")
+time.sleep(3)
+
+# Test modify
+modify_order = Order(
+    order_id=buy_id,
+    market="BTC-USD-PERP",
+    order_type=OrderType.Limit,
+    order_side=OrderSide.Buy,
+    size=Decimal("0.01"),
+    limit_price=Decimal(9500),
+    client_id=buy_client_id,
+    instruction="POST_ONLY",
+    reduce_only=False,
+)
+response = paradex.api_client.modify_order(buy_id, modify_order)
+logger.info(f"Modify order response {response}")
+
+
+# Cancel ETH open order
+paradex.api_client.cancel_all_orders({"market": "ETH-USD-PERP"})
+orders = paradex.api_client.fetch_orders()
+logger.info(f"After ETH-USD-PERP Cancel {orders=}")
+paradex.api_client.cancel_order(order_id=buy_id)
+orders = paradex.api_client.fetch_orders()
+logger.info(f"After BUY Cancel {orders=}")
+
+
+# Place Parent Order with Attached Take Profit and Stop Loss Orders
+# using Batch Orders API
+order = Order(
+    market="BTC-USD-PERP",
+    order_type=OrderType.Limit,
+    order_side=OrderSide.Buy,
+    size=Decimal("0.01"),
+    limit_price=Decimal(95_000),
+)
+taker_profit_order = Order(
+    market="BTC-USD-PERP",
+    order_type=OrderType.TakeProfitMarket,
+    order_side=OrderSide.Sell,
+    size=Decimal("0.01"),
+    trigger_price=Decimal(100_0000),
+    reduce_only=True,
+)
+stop_loss_order = Order(
+    market="BTC-USD-PERP",
+    order_type=OrderType.StopLossMarket,
+    order_side=OrderSide.Sell,
+    size=Decimal("0.01"),
+    trigger_price=Decimal(90_000),
+    reduce_only=True,
+)
+orders = [
+    order,
+    taker_profit_order,
+    stop_loss_order,
+]
+response = paradex.api_client.submit_orders_batch(orders=orders)
+logger.info(f"Batch of orders {response=}")

--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -43,11 +43,22 @@ class ParadexAccount:
         l1_address (Optional[str], optional): Ethereum address. Defaults to None.
         l1_private_key (Optional[str], optional): Ethereum private key. Defaults to None.
         l2_private_key (Optional[str], optional): Paradex private key. Defaults to None.
+        l2_address (Optional[str], optional): L2 address. Defaults to None.
+
+    Note:
+        - If only L2 private key is provided, authentication will happen without onboarding. Account must have been onboarded previously.
+        - if L2 private key is a subkey, L2 address of the main account must be provided.
 
     Examples:
         >>> from paradex_py import Paradex
         >>> from paradex_py.environment import Environment
+        >>> # L1+L2 authentication (traditional)
         >>> paradex = Paradex(env=Environment.TESTNET, l1_address="0x...", l1_private_key="0x...")
+        >>> paradex.account.l2_address
+        >>> paradex.account.l2_public_key
+        >>> paradex.account.l2_private_key
+        >>> # L2-only authentication (subkey)
+        >>> paradex = Paradex(env=Environment.TESTNET, l2_private_key="0x...", l2_address="0x...")
         >>> paradex.account.l2_address
         >>> paradex.account.l2_public_key
         >>> paradex.account.l2_private_key

--- a/paradex_py/account/starknet.py
+++ b/paradex_py/account/starknet.py
@@ -78,7 +78,7 @@ class Account(StarknetAccount):
             proxy_config = get_proxy_config() if is_cairo0_contract else False
             contract = await Contract.from_address(address=address, provider=self, proxy_config=proxy_config)
         except Exception as e:
-            logging.error(f"Error loading contract at address {hex(int(address))}: {e}")
+            logging.exception(f"Error loading contract at address {hex(int(address))}: {e}")
             raise
         else:
             return contract
@@ -99,7 +99,7 @@ class Account(StarknetAccount):
 
             need_multisig = current_guardian != "0x0" or current_guardian_backup != "0x0"
         except Exception as e:
-            logging.error(f"Error checking multisig requirement: {e}")
+            logging.exception(f"Error checking multisig requirement: {e}")
             raise
         else:
             return need_multisig
@@ -131,7 +131,7 @@ class Account(StarknetAccount):
                     " command."
                 )
         except Exception as e:
-            logging.error(f"Error processing invoke: {e}")
+            logging.exception(f"Error processing invoke: {e}")
             raise
 
     def print_invoke(self, invoke: InvokeV3):

--- a/paradex_py/api/api_client.py
+++ b/paradex_py/api/api_client.py
@@ -42,7 +42,8 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
 
     def init_account(self, account: ParadexAccount):
         self.account = account
-        self.onboarding()
+        if self.account.l1_address is not None:
+            self.onboarding()
         self.auth()
 
     def onboarding(self):
@@ -52,7 +53,8 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
 
     def auth(self):
         headers = self.account.auth_headers()
-        res = self.post(api_url=self.api_url, path="auth", headers=headers)
+        public_key = hex(self.account.l2_public_key)
+        res = self.post(api_url=self.api_url, path=f"auth/{public_key}", headers=headers)
         data = AuthSchema().load(res, unknown="exclude", partial=True)
         self.auth_timestamp = time.time()
         self.account.set_jwt_token(data.jwt_token)

--- a/paradex_py/api/generated/__init__.py
+++ b/paradex_py/api/generated/__init__.py
@@ -2,7 +2,6 @@
 
 """Generated API models from Paradex OpenAPI spec v1.97.0."""
 
-# ruff: noqa: F403, A003
 # Import all generated models
 from .requests import *
 from .responses import *

--- a/paradex_py/paradex.py
+++ b/paradex_py/paradex.py
@@ -16,15 +16,23 @@ class Paradex:
         l1_address (str, optional): L1 address. Defaults to None.
         l1_private_key (str, optional): L1 private key. Defaults to None.
         l2_private_key (str, optional): L2 private key. Defaults to None.
+        l2_address (str, optional): L2 address. Defaults to None.
         logger (logging.Logger, optional): Logger. Defaults to None.
         ws_timeout (int, optional): WebSocket read timeout in seconds. Defaults to None (uses default).
+
+    Note:
+        - If only L2 private key is provided, the account will be authenticated directly (L2-only mode)
+        - For subkeys, L2 address of the main accountmust be provided.
 
     Examples:
         >>> from paradex_py import Paradex
         >>> from paradex_py.environment import Environment
-        >>> paradex = Paradex(env=Environment.TESTNET)
+        >>> # L1+L2 authentication (traditional)
+        >>> paradex = Paradex(env=Environment.TESTNET, l1_address="0x...", l1_private_key="0x...")
+        >>> # L2-only authentication (subkey)
+        >>> paradex = Paradex(env=Environment.TESTNET, l2_private_key="0x...", l2_address="0x...")
         >>> # With custom timeout
-        >>> paradex = Paradex(env=Environment.TESTNET, ws_timeout=30)
+        >>> paradex = Paradex(env=Environment.TESTNET, l2_private_key="0x...", ws_timeout=30)
     """
 
     def __init__(

--- a/paradex_py/paradex.py
+++ b/paradex_py/paradex.py
@@ -33,6 +33,7 @@ class Paradex:
         l1_address: Optional[str] = None,
         l1_private_key: Optional[str] = None,
         l2_private_key: Optional[str] = None,
+        l2_address: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
         ws_timeout: Optional[int] = None,
     ):
@@ -47,18 +48,20 @@ class Paradex:
         self.account: Optional[ParadexAccount] = None
 
         # Initialize account if private key is provided
-        if l1_address and (l2_private_key is not None or l1_private_key is not None):
+        if l2_private_key is not None or l1_private_key is not None:
             self.init_account(
                 l1_address=l1_address,
                 l1_private_key=l1_private_key,
                 l2_private_key=l2_private_key,
+                l2_address=l2_address,
             )
 
     def init_account(
         self,
-        l1_address: str,
+        l1_address: Optional[str] = None,
         l1_private_key: Optional[str] = None,
         l2_private_key: Optional[str] = None,
+        l2_address: Optional[str] = None,
     ):
         """Initialize paradex account with l1 or l2 private keys.
         Cannot be called if account is already initialized.
@@ -75,6 +78,7 @@ class Paradex:
             l1_address=l1_address,
             l1_private_key=l1_private_key,
             l2_private_key=l2_private_key,
+            l2_address=l2_address,
         )
         self.api_client.init_account(self.account)
         self.ws_client.init_account(self.account)


### PR DESCRIPTION
We are launching a new feature, Subkeys. 

Subkeys are basically trade-only private keys that are tied to an account. Users can now grant trade-only access to others by inputting a Subkey in place of the Private Key.

Users with subkeys can do anything the main account user can EXCEPT withdraw and transfer funds

In this PR:
- Modifies the account setup process so that it doesn't strictly require an L1 address
- If L1 address is not provided, we skip the onboarding process (So account needs to have been onboarded before)
- Users can now specify L2 Private key directly to use paradex-py
- Users can also use Subkeys by inputting the L2_ADDRESS and L2_PRIVATE_KEY vairiables