### PR TITLE
Support custom RPC version parameter

### DIFF
--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -43,6 +43,7 @@ class ParadexAccount:
         l1_address (str): Ethereum address
         l1_private_key (Optional[str], optional): Ethereum private key. Defaults to None.
         l2_private_key (Optional[str], optional): Paradex private key. Defaults to None.
+        rpc_version (Optional[str], optional): RPC version (e.g., "v0_9"). If provided, constructs URL as {base_url}/rpc/{rpc_version}. Defaults to None.
 
     Examples:
         >>> from paradex_py import Paradex
@@ -60,6 +61,7 @@ class ParadexAccount:
         l1_private_key_from_ledger: bool | None = False,
         l1_private_key: str | None = None,
         l2_private_key: str | None = None,
+        rpc_version: str | None = None,
     ):
         self.config = config
 
@@ -84,7 +86,11 @@ class ParadexAccount:
         self.l2_address = self._account_address()
 
         # Create starknet account
-        client = FullNodeClient(node_url=config.starknet_fullnode_rpc_url)
+        if rpc_version:
+            node_url = f"{config.starknet_fullnode_rpc_base_url}/rpc/{rpc_version}"
+        else:
+            node_url = config.starknet_fullnode_rpc_url
+        client = FullNodeClient(node_url=node_url)
         self.l2_chain_id = int_from_bytes(config.starknet_chain_id.encode())
         self.starknet = StarknetAccount(
             client=client,

--- a/paradex_py/api/api_client.py
+++ b/paradex_py/api/api_client.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import re
 import time
 from typing import Any, cast
 
@@ -579,6 +580,10 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
             url=f"{self.api_url}/system/config",
             http_method=HttpMethod.GET,
         )
+        # Extract base URL from full URL if not provided in response
+        if "starknet_fullnode_rpc_base_url" not in res and "starknet_fullnode_rpc_url" in res:
+            base_url = re.sub(r"/rpc/v\d+[._]\d+.*$", "", res["starknet_fullnode_rpc_url"])
+            res["starknet_fullnode_rpc_base_url"] = base_url
         config = SystemConfigSchema().load(res, unknown="exclude", partial=True)
         self.logger.info(f"{self.classname}: SystemConfig:{config}")
         return config

--- a/paradex_py/api/models.py
+++ b/paradex_py/api/models.py
@@ -25,6 +25,7 @@ class BridgedToken:
 class SystemConfig:
     starknet_gateway_url: str
     starknet_fullnode_rpc_url: str
+    starknet_fullnode_rpc_base_url: str
     starknet_chain_id: str
     block_explorer_url: str
     paraclear_address: str

--- a/paradex_py/paradex.py
+++ b/paradex_py/paradex.py
@@ -45,6 +45,7 @@ class Paradex:
         auto_auth (bool, optional): Whether to automatically handle onboarding/auth. Defaults to True.
         auth_provider (AuthProvider, optional): Custom authentication provider. Defaults to None.
         signer (Signer, optional): Custom order signer for submit/modify/batch operations. Defaults to None.
+        rpc_version (str, optional): RPC version (e.g., "v0_9"). If provided, constructs URL as {base_url}/rpc/{rpc_version}. Defaults to None.
 
     Examples:
         >>> from paradex_py import Paradex
@@ -86,6 +87,8 @@ class Paradex:
         auth_provider: "AuthProvider | None" = None,
         # Signing configuration
         signer: "Signer | None" = None,
+        # RPC configuration
+        rpc_version: str | None = None,
     ):
         if env is None:
             return raise_value_error("Paradex: Invalid environment")
@@ -137,6 +140,7 @@ class Paradex:
                 l1_address=l1_address,
                 l1_private_key=l1_private_key,
                 l2_private_key=l2_private_key,
+                rpc_version=rpc_version,
             )
 
     def init_account(
@@ -144,6 +148,7 @@ class Paradex:
         l1_address: str,
         l1_private_key: str | None = None,
         l2_private_key: str | None = None,
+        rpc_version: str | None = None,
     ):
         """Initialize paradex account with l1 or l2 private keys.
         Cannot be called if account is already initialized.
@@ -152,6 +157,7 @@ class Paradex:
             l1_address (str): L1 address
             l1_private_key (str): L1 private key
             l2_private_key (str): L2 private key
+            rpc_version (str, optional): RPC version (e.g., "v0_9"). If provided, constructs URL as {base_url}/rpc/{rpc_version}. Defaults to None.
         """
         if self.account is not None:
             return raise_value_error("Paradex: Account already initialized")
@@ -160,6 +166,7 @@ class Paradex:
             l1_address=l1_address,
             l1_private_key=l1_private_key,
             l2_private_key=l2_private_key,
+            rpc_version=rpc_version,
         )
         self.api_client.init_account(self.account)
         self.ws_client.init_account(self.account)

--- a/tests/api/test_rpc_version.py
+++ b/tests/api/test_rpc_version.py
@@ -1,0 +1,171 @@
+"""Tests for RPC version functionality in ParadexAccount and Paradex."""
+
+from unittest.mock import MagicMock, patch
+
+from paradex_py import Paradex
+from paradex_py.account.account import ParadexAccount
+from paradex_py.environment import TESTNET
+from tests.mocks.api_client import MockApiClient
+
+TEST_L1_ADDRESS = "0xd2c7314539dCe7752c8120af4eC2AA750Cf2035e"
+TEST_L1_PRIVATE_KEY = "0xf8e4d1d772cdd44e5e77615ad11cc071c94e4c06dc21150d903f28e6aa6abdff"
+TEST_L2_PRIVATE_KEY = "0x543b6cf6c91817a87174aaea4fb370ac1c694e864d7740d728f8344d53e815"
+
+
+class TestParadexAccountRpcVersion:
+    """Test RPC version functionality in ParadexAccount."""
+
+    def test_account_without_rpc_version(self):
+        """Test that account uses default RPC URL when rpc_version is not provided."""
+        api_client = MockApiClient()
+        config = api_client.fetch_system_config()
+
+        with patch("paradex_py.account.account.FullNodeClient") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            ParadexAccount(
+                config=config,
+                l1_address=TEST_L1_ADDRESS,
+                l1_private_key=TEST_L1_PRIVATE_KEY,
+            )
+
+            # Verify that FullNodeClient was called with the default RPC URL
+            mock_client.assert_called_once()
+            call_args = mock_client.call_args
+            assert call_args.kwargs["node_url"] == config.starknet_fullnode_rpc_url
+            assert call_args.kwargs["node_url"] == "https://pathfinder.api.testnet.paradex.trade/rpc/v0.5"
+
+    def test_account_with_rpc_version(self):
+        """Test that account constructs RPC URL with version when rpc_version is provided."""
+        api_client = MockApiClient()
+        config = api_client.fetch_system_config()
+
+        with patch("paradex_py.account.account.FullNodeClient") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            ParadexAccount(
+                config=config,
+                l1_address=TEST_L1_ADDRESS,
+                l1_private_key=TEST_L1_PRIVATE_KEY,
+                rpc_version="v0_9",
+            )
+
+            # Verify that FullNodeClient was called with the constructed URL
+            mock_client.assert_called_once()
+            call_args = mock_client.call_args
+            expected_url = f"{config.starknet_fullnode_rpc_base_url}/rpc/v0_9"
+            assert call_args.kwargs["node_url"] == expected_url
+            assert call_args.kwargs["node_url"] == "https://pathfinder.api.testnet.paradex.trade/rpc/v0_9"
+
+    def test_account_with_different_rpc_version(self):
+        """Test that account works with different RPC versions."""
+        api_client = MockApiClient()
+        config = api_client.fetch_system_config()
+
+        with patch("paradex_py.account.account.FullNodeClient") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            ParadexAccount(
+                config=config,
+                l1_address=TEST_L1_ADDRESS,
+                l2_private_key=TEST_L2_PRIVATE_KEY,
+                rpc_version="v0_8",
+            )
+
+            # Verify that FullNodeClient was called with the correct version
+            mock_client.assert_called_once()
+            call_args = mock_client.call_args
+            expected_url = f"{config.starknet_fullnode_rpc_base_url}/rpc/v0_8"
+            assert call_args.kwargs["node_url"] == expected_url
+            assert call_args.kwargs["node_url"] == "https://pathfinder.api.testnet.paradex.trade/rpc/v0_8"
+
+
+class TestParadexRpcVersion:
+    """Test RPC version functionality in Paradex class."""
+
+    def test_paradex_init_account_with_rpc_version(self):
+        """Test that Paradex.init_account passes rpc_version to ParadexAccount."""
+        # Create a mock Paradex instance
+        paradex = Paradex.__new__(Paradex)
+        paradex.env = TESTNET
+        paradex.logger = MagicMock()
+        paradex.api_client = MockApiClient()
+        paradex.ws_client = MagicMock()
+        paradex.config = paradex.api_client.fetch_system_config()
+        paradex.account = None
+
+        with patch("paradex_py.account.account.FullNodeClient") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            # Initialize account with rpc_version
+            paradex.init_account(
+                l1_address=TEST_L1_ADDRESS,
+                l1_private_key=TEST_L1_PRIVATE_KEY,
+                rpc_version="v0_9",
+            )
+
+            # Verify that FullNodeClient was called with the correct URL
+            mock_client.assert_called_once()
+            call_args = mock_client.call_args
+            expected_url = f"{paradex.config.starknet_fullnode_rpc_base_url}/rpc/v0_9"
+            assert call_args.kwargs["node_url"] == expected_url
+            assert paradex.account is not None
+
+    @patch("paradex_py.paradex.ParadexApiClient")
+    @patch("paradex_py.paradex.ParadexWebsocketClient")
+    def test_paradex_init_with_rpc_version(self, mock_ws_client, mock_api_client):
+        """Test that Paradex.__init__ passes rpc_version to ParadexAccount."""
+        # Setup mocks
+        mock_api_instance = MockApiClient()
+        mock_api_client.return_value = mock_api_instance
+        mock_ws_client.return_value = MagicMock()
+
+        with patch("paradex_py.account.account.FullNodeClient") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            # Create Paradex instance with rpc_version
+            paradex = Paradex(
+                env=TESTNET,
+                l1_address=TEST_L1_ADDRESS,
+                l1_private_key=TEST_L1_PRIVATE_KEY,
+                rpc_version="v0_9",
+            )
+
+            # Verify that FullNodeClient was called with the correct URL
+            mock_client.assert_called_once()
+            call_args = mock_client.call_args
+            expected_url = f"{paradex.config.starknet_fullnode_rpc_base_url}/rpc/v0_9"
+            assert call_args.kwargs["node_url"] == expected_url
+            assert paradex.account is not None
+
+    @patch("paradex_py.paradex.ParadexApiClient")
+    @patch("paradex_py.paradex.ParadexWebsocketClient")
+    def test_paradex_init_without_rpc_version(self, mock_ws_client, mock_api_client):
+        """Test that Paradex.__init__ uses default RPC URL when rpc_version is not provided."""
+        # Setup mocks
+        mock_api_instance = MockApiClient()
+        mock_api_client.return_value = mock_api_instance
+        mock_ws_client.return_value = MagicMock()
+
+        with patch("paradex_py.account.account.FullNodeClient") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+
+            # Create Paradex instance without rpc_version
+            paradex = Paradex(
+                env=TESTNET,
+                l1_address=TEST_L1_ADDRESS,
+                l1_private_key=TEST_L1_PRIVATE_KEY,
+            )
+
+            # Verify that FullNodeClient was called with default RPC URL
+            mock_client.assert_called_once()
+            call_args = mock_client.call_args
+            assert call_args.kwargs["node_url"] == paradex.config.starknet_fullnode_rpc_url
+            assert call_args.kwargs["node_url"] == "https://pathfinder.api.testnet.paradex.trade/rpc/v0.5"
+            assert paradex.account is not None

--- a/tests/mocks/api_client.py
+++ b/tests/mocks/api_client.py
@@ -3,6 +3,7 @@ from paradex_py.api.models import SystemConfig, SystemConfigSchema
 MOCK_CONFIG = {
     "starknet_gateway_url": "https://potc-testnet-sepolia.starknet.io",
     "starknet_fullnode_rpc_url": "https://pathfinder.api.testnet.paradex.trade/rpc/v0.5",
+    "starknet_fullnode_rpc_base_url": "https://pathfinder.api.testnet.paradex.trade",
     "starknet_chain_id": "PRIVATE_SN_POTC_SEPOLIA",
     "block_explorer_url": "https://voyager.testnet.paradex.trade/",
     "paraclear_address": "0x286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6",
@@ -31,3 +32,7 @@ MOCK_CONFIG = {
 class MockApiClient:
     def fetch_system_config(self) -> SystemConfig:
         return SystemConfigSchema().load(MOCK_CONFIG)
+
+    def init_account(self, account):
+        """Mock init_account method for testing."""
+        self.account = account


### PR DESCRIPTION
### Summary
Adds support for specifying a custom RPC version when
initializing Paradex accounts.

When `rpc_version` is provided, the client constructs
the fullnode URL using the base URL and the specified version.

The implementation includes backward compatibility to extract
the base URL from the full RPC URL when not provided by the API.

### Changes
- Added optional `rpc_version` parameter to `Paradex` and `ParadexAccount` initialization
- Added `starknet_fullnode_rpc_base_url` field to system configuration
- When `rpc_version` is specified, constructs RPC URL as `{base_url}/rpc/{rpc_version}`
- Falls back to default RPC URL when `rpc_version` is not provided
- Automatically extracts base URL from full RPC URL if not provided by API response