### PR TITLE
Fix: add auto_estimate=True to transfer_on_l2()

### DIFF
--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -265,7 +265,7 @@ class ParadexAccount:
 
             # Prepare and send transaction
             func_name = "transferOnL2"
-            prepared_invoke = await self.starknet.prepare_invoke(calls=calls)
+            prepared_invoke = await self.starknet.prepare_invoke(calls=calls, auto_estimate=True)
             await self.starknet.process_invoke(account_contract, need_multisig, prepared_invoke, func_name)
 
         except Exception as e:


### PR DESCRIPTION
## Problem

`transfer_on_l2()` method fails on paradex-py 0.5.4 with starknet-py 0.28.x:

```
ValueError: One of arguments: resource_bounds or auto_estimate must be specified when invoking a transaction.
```

## Root Cause

In the commit that removed `random_resource_bounds()`, the `transfer_on_l2()` method was not updated to pass `auto_estimate=True` to `prepare_invoke()`.

**File**: `paradex_py/account/account.py`, line 268

## Fix

```python
# Before
prepared_invoke = await self.starknet.prepare_invoke(calls=calls)

# After  
prepared_invoke = await self.starknet.prepare_invoke(calls=calls, auto_estimate=True)
```

## Testing

Tested successfully with:
- paradex-py: 0.5.4
- starknet-py: 0.28.1
- Python: 3.11

Transfer completed without errors after applying this fix.