### PR TITLE
Add versioned User-Agent header to HTTP and WebSocket clients

### DIFF
--- a/paradex_py/api/http_client.py
+++ b/paradex_py/api/http_client.py
@@ -6,6 +6,7 @@ import httpx
 
 from paradex_py.api.models import ApiErrorSchema
 from paradex_py.api.protocols import RequestHook, RetryStrategy
+from paradex_py.user_agent import get_user_agent
 from paradex_py.utils import raise_value_error
 
 
@@ -35,12 +36,20 @@ class HttpClient:
         """
         if http_client is not None:
             self.client = http_client
+            # Only set headers if not already set in custom client
+            if "Content-Type" not in self.client.headers:
+                self.client.headers.update({"Content-Type": "application/json"})
+            if "User-Agent" not in self.client.headers:
+                self.client.headers.update({"User-Agent": get_user_agent()})
         else:
             self.client = httpx.Client()
-
-        # Only set default headers if they're not already set
-        if "Content-Type" not in self.client.headers:
-            self.client.headers.update({"Content-Type": "application/json"})
+            # Always set our headers for default client (overriding httpx defaults)
+            self.client.headers.update(
+                {
+                    "Content-Type": "application/json",
+                    "User-Agent": get_user_agent(),
+                }
+            )
 
         self.default_timeout = default_timeout
         self.retry_strategy = retry_strategy

--- a/paradex_py/api/ws_client.py
+++ b/paradex_py/api/ws_client.py
@@ -15,6 +15,7 @@ from websockets import ClientConnection, State
 from paradex_py.account.account import ParadexAccount
 from paradex_py.constants import WS_TIMEOUT
 from paradex_py.environment import Environment
+from paradex_py.user_agent import get_user_agent
 
 # Optional typed message models
 try:
@@ -223,7 +224,7 @@ class ParadexWebsocketClient:
 
         try:
             self.subscribed_channels = {}
-            extra_headers = {}
+            extra_headers = {"User-Agent": get_user_agent()}
             if self.account:
                 extra_headers.update({"Authorization": f"Bearer {self.account.jwt_token}"})
 

--- a/paradex_py/user_agent.py
+++ b/paradex_py/user_agent.py
@@ -1,0 +1,34 @@
+"""User agent utility for HTTP and WebSocket clients."""
+
+import platform
+import sys
+from importlib.metadata import PackageNotFoundError, version
+
+
+def get_user_agent() -> str:
+    """Generate a formatted User-Agent header for paradex-py SDK.
+
+    Format: paradex-py/{VERSION} (Python {PYTHON_VERSION}; {PLATFORM})
+
+    Returns:
+        str: Formatted user agent string
+
+    Examples:
+        >>> agent = get_user_agent()
+        >>> print(agent)
+        paradex-py/0.5.4 (Python 3.11.14; Darwin)
+    """
+    # Get SDK version
+    try:
+        sdk_version = version("paradex_py")
+    except PackageNotFoundError:
+        # Fallback for development mode when package not installed
+        sdk_version = "dev"
+
+    # Get Python version (e.g., "3.11.14")
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+    # Get platform name (e.g., "Darwin", "Linux", "Windows")
+    platform_name = platform.system()
+
+    return f"paradex-py/{sdk_version} (Python {python_version}; {platform_name})"

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,0 +1,79 @@
+"""Tests for user_agent module."""
+
+import platform
+import sys
+from unittest.mock import patch
+
+from paradex_py.user_agent import get_user_agent
+
+
+class TestUserAgent:
+    """Test suite for user agent generation."""
+
+    def test_user_agent_format(self):
+        """Test that user agent follows expected format."""
+        user_agent = get_user_agent()
+
+        # Should contain all required components
+        assert "paradex-py/" in user_agent
+        assert "Python" in user_agent
+        assert platform.system() in user_agent
+
+    def test_user_agent_includes_sdk_version(self):
+        """Test that user agent includes SDK version."""
+        user_agent = get_user_agent()
+
+        # Should have version after paradex-py/
+        assert user_agent.startswith("paradex-py/")
+        version_part = user_agent.split("paradex-py/")[1].split(" ")[0]
+        # Version should be either semver format or "dev"
+        assert version_part == "dev" or "." in version_part
+
+    def test_user_agent_includes_python_version(self):
+        """Test that user agent includes Python version."""
+        user_agent = get_user_agent()
+
+        expected_python = f"Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        assert expected_python in user_agent
+
+    def test_user_agent_includes_platform(self):
+        """Test that user agent includes platform."""
+        user_agent = get_user_agent()
+
+        platform_name = platform.system()
+        assert platform_name in user_agent
+
+    def test_user_agent_fallback_dev_version(self):
+        """Test that user agent falls back to 'dev' when package not installed."""
+        from importlib.metadata import PackageNotFoundError
+
+        with patch("paradex_py.user_agent.version", side_effect=PackageNotFoundError("Package not found")):
+            user_agent = get_user_agent()
+
+            # Should fallback to "dev"
+            assert "paradex-py/dev" in user_agent
+
+    def test_user_agent_structure(self):
+        """Test that user agent has correct structure."""
+        user_agent = get_user_agent()
+
+        # Expected format: "paradex-py/{VERSION} (Python {PYTHON_VERSION}; {PLATFORM})"
+        parts = user_agent.split(" ", 1)
+        assert len(parts) == 2
+        assert parts[0].startswith("paradex-py/")
+        assert parts[1].startswith("(")
+        assert parts[1].endswith(")")
+
+        # Check inner part
+        inner = parts[1][1:-1]  # Remove parentheses
+        inner_parts = inner.split("; ")
+        assert len(inner_parts) == 2
+        assert inner_parts[0].startswith("Python ")
+        # inner_parts[1] is the platform
+
+    def test_user_agent_consistent(self):
+        """Test that user agent returns consistent value across multiple calls."""
+        user_agent1 = get_user_agent()
+        user_agent2 = get_user_agent()
+
+        assert user_agent1 == user_agent2


### PR DESCRIPTION
## Summary
Adds automatic User-Agent header to all HTTP and WebSocket requests for better request tracking and analytics.

## Changes
- **New module**: `paradex_py/user_agent.py` with `get_user_agent()` function
- **HTTP client**: Sets User-Agent header on initialization
- **WebSocket client**: Includes User-Agent in connection headers
- **Tests**: Comprehensive test suite with 7 new tests

## Format
```
paradex-py/{VERSION} (Python {PYTHON_VERSION}; {PLATFORM})
```

Example: `paradex-py/0.5.4 (Python 3.11.14; Darwin)`

## Technical Details
- Version sourced from `importlib.metadata` (single source of truth)
- Falls back to "dev" in development mode
- Preserves custom User-Agent when using injected clients
- Fully backward compatible (no breaking changes)

## Testing
- ✅ All 175 tests passing (including 7 new user-agent tests)
- ✅ Type checking (mypy)
- ✅ Linting (ruff, black)
- ✅ Coverage maintained