### PR TITLE
Add protocol compression support

### DIFF
--- a/paradex_py/paradex.py
+++ b/paradex_py/paradex.py
@@ -35,6 +35,7 @@ class Paradex:
         default_timeout (float, optional): Default HTTP request timeout in seconds. Defaults to None.
         retry_strategy (RetryStrategy, optional): Custom retry/backoff strategy. Defaults to None.
         request_hook (RequestHook, optional): Hook for request/response observability. Defaults to None.
+        enable_http_compression (bool, optional): Enable HTTP compression (gzip, deflate, br). Defaults to True.
         auto_start_ws_reader (bool, optional): Whether to automatically start WS message reader. Defaults to True.
         ws_connector (WebSocketConnector, optional): Custom WebSocket connector for injection. Defaults to None.
         ws_url_override (str, optional): Custom WebSocket URL override. Defaults to None.
@@ -43,6 +44,7 @@ class Paradex:
         validate_ws_messages (bool, optional): Enable JSON-RPC message validation. Defaults to False.
         ping_interval (float, optional): WebSocket ping interval in seconds. Defaults to None.
         disable_reconnect (bool, optional): Disable automatic WebSocket reconnection. Defaults to False.
+        enable_ws_compression (bool, optional): Enable WebSocket per-message compression (RFC 7692). Defaults to True.
         auto_auth (bool, optional): Whether to automatically handle onboarding/auth. Defaults to True.
         auth_provider (AuthProvider, optional): Custom authentication provider. Defaults to None.
         signer (Signer, optional): Custom order signer for submit/modify/batch operations. Defaults to None.
@@ -75,6 +77,7 @@ class Paradex:
         default_timeout: float | None = None,
         retry_strategy: "RetryStrategy | None" = None,
         request_hook: "RequestHook | None" = None,
+        enable_http_compression: bool = True,
         # WebSocket client injection and configuration
         auto_start_ws_reader: bool = True,
         ws_connector: "WebSocketConnector | None" = None,
@@ -84,6 +87,7 @@ class Paradex:
         validate_ws_messages: bool = False,
         ping_interval: float | None = None,
         disable_reconnect: bool = False,
+        enable_ws_compression: bool = True,
         # Auth configuration
         auto_auth: bool = True,
         auth_provider: "AuthProvider | None" = None,
@@ -99,13 +103,14 @@ class Paradex:
         self.logger: logging.Logger = logger or logging.getLogger(__name__)
 
         # Create enhanced HTTP client if needed
-        if http_client is None and (default_timeout or retry_strategy or request_hook):
+        if http_client is None and (default_timeout or retry_strategy or request_hook or not enable_http_compression):
             from paradex_py.api.http_client import HttpClient
 
             http_client = HttpClient(
                 default_timeout=default_timeout,
                 retry_strategy=retry_strategy,
                 request_hook=request_hook,
+                enable_compression=enable_http_compression,
             )
 
         # Load api client and system config with all optional injection
@@ -132,6 +137,7 @@ class Paradex:
             validate_messages=validate_ws_messages,
             ping_interval=ping_interval,
             disable_reconnect=disable_reconnect,
+            enable_compression=enable_ws_compression,
         )
 
         if config is not None:

--- a/tests/api/test_http_compression.py
+++ b/tests/api/test_http_compression.py
@@ -1,0 +1,104 @@
+"""Tests for HTTP compression support in HttpClient."""
+
+import httpx
+
+from paradex_py.api.http_client import HttpClient
+from paradex_py.environment import TESTNET
+from paradex_py.paradex import Paradex
+
+
+class TestHttpCompression:
+    """Test suite for HTTP compression configuration."""
+
+    def test_compression_enabled_by_default(self):
+        """Test that compression is enabled by default (httpx default behavior)."""
+        http_client = HttpClient()
+
+        # When compression is enabled, httpx automatically adds Accept-Encoding header
+        # or doesn't explicitly set "identity"
+        assert (
+            "Accept-Encoding" not in http_client.client.headers
+            or http_client.client.headers["Accept-Encoding"] != "identity"
+        )
+
+    def test_compression_explicitly_enabled(self):
+        """Test that compression can be explicitly enabled."""
+        http_client = HttpClient(enable_compression=True)
+
+        # Should not set Accept-Encoding to identity
+        assert (
+            "Accept-Encoding" not in http_client.client.headers
+            or http_client.client.headers["Accept-Encoding"] != "identity"
+        )
+
+    def test_compression_disabled(self):
+        """Test that compression can be disabled."""
+        http_client = HttpClient(enable_compression=False)
+
+        # Should set Accept-Encoding to identity
+        assert http_client.client.headers["Accept-Encoding"] == "identity"
+
+    def test_compression_disabled_with_custom_client(self):
+        """Test that compression can be disabled with custom injected client."""
+        custom_client = httpx.Client()
+        http_client = HttpClient(http_client=custom_client, enable_compression=False)
+
+        # Should set Accept-Encoding to identity on custom client
+        assert http_client.client.headers["Accept-Encoding"] == "identity"
+
+    def test_compression_enabled_with_custom_client(self):
+        """Test that compression is left as default with custom client when enabled."""
+        custom_client = httpx.Client()
+        http_client = HttpClient(http_client=custom_client, enable_compression=True)
+
+        # Should not modify Accept-Encoding header when compression is enabled
+        assert (
+            "Accept-Encoding" not in http_client.client.headers
+            or http_client.client.headers["Accept-Encoding"] != "identity"
+        )
+
+    def test_compression_overrides_custom_accept_encoding_when_disabled(self):
+        """Test that disabling compression overrides custom Accept-Encoding header."""
+        custom_client = httpx.Client()
+        custom_client.headers["Accept-Encoding"] = "custom-encoding"
+        http_client = HttpClient(http_client=custom_client, enable_compression=False)
+
+        # When compression is explicitly disabled, should override custom Accept-Encoding
+        assert http_client.client.headers["Accept-Encoding"] == "identity"
+
+    def test_compression_disabled_via_paradex_constructor(self):
+        """Test that compression can be disabled via Paradex constructor."""
+        paradex = Paradex(env=TESTNET, enable_http_compression=False)
+
+        # Should have created an HttpClient with compression disabled
+        assert paradex.api_client.client.headers["Accept-Encoding"] == "identity"
+
+    def test_compression_enabled_via_paradex_constructor(self):
+        """Test that compression is enabled via Paradex constructor."""
+        paradex = Paradex(env=TESTNET, enable_http_compression=True)
+
+        # Should not have Accept-Encoding set to identity
+        assert (
+            "Accept-Encoding" not in paradex.api_client.client.headers
+            or paradex.api_client.client.headers["Accept-Encoding"] != "identity"
+        )
+
+    def test_compression_default_via_paradex_constructor(self):
+        """Test that compression is enabled by default when not specified."""
+        paradex = Paradex(env=TESTNET)
+
+        # Should use default compression behavior (not set to identity)
+        # Note: Paradex doesn't create HttpClient when all parameters are default
+        # So we check the underlying httpx client in the API client
+        assert (
+            "Accept-Encoding" not in paradex.api_client.client.headers
+            or paradex.api_client.client.headers["Accept-Encoding"] != "identity"
+        )
+
+    def test_compression_with_other_http_options(self):
+        """Test that compression works alongside other HTTP options."""
+        http_client = HttpClient(enable_compression=False, default_timeout=30.0)
+
+        # Should have both compression disabled and timeout set
+        assert http_client.client.headers["Accept-Encoding"] == "identity"
+        assert http_client.default_timeout == 30.0

--- a/tests/api/test_ws_compression.py
+++ b/tests/api/test_ws_compression.py
@@ -1,0 +1,162 @@
+"""Tests for WebSocket compression support in ParadexWebsocketClient."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from websockets import State
+
+from paradex_py.api.ws_client import ParadexWebsocketClient
+from paradex_py.environment import TESTNET
+from paradex_py.paradex import Paradex
+
+MOCK_L1_PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+MOCK_L1_ADDRESS = "0xabcdef0123456789abcdef0123456789abcdef01"
+
+
+class TestWebSocketCompression:
+    """Test suite for WebSocket compression configuration."""
+
+    def test_compression_enabled_by_default(self):
+        """Test that compression is enabled by default."""
+        ws_client = ParadexWebsocketClient(env=TESTNET)
+
+        # Should have enable_compression=True by default
+        assert ws_client.enable_compression is True
+
+    def test_compression_explicitly_enabled(self):
+        """Test that compression can be explicitly enabled."""
+        ws_client = ParadexWebsocketClient(env=TESTNET, enable_compression=True)
+
+        # Should have enable_compression=True
+        assert ws_client.enable_compression is True
+
+    def test_compression_disabled(self):
+        """Test that compression can be disabled."""
+        ws_client = ParadexWebsocketClient(env=TESTNET, enable_compression=False)
+
+        # Should have enable_compression=False
+        assert ws_client.enable_compression is False
+
+    @pytest.mark.asyncio
+    @patch("websockets.connect", new_callable=AsyncMock)
+    async def test_compression_enabled_connect_kwargs(self, mock_connect: AsyncMock):
+        """Test that compression enabled does not add compression=None to kwargs."""
+        mock_ws_connection = AsyncMock()
+        mock_ws_connection.state = State.OPEN
+        mock_connect.return_value = mock_ws_connection
+
+        ws_client = ParadexWebsocketClient(env=TESTNET, enable_compression=True)
+        await ws_client.connect()
+
+        # Verify compression is not in kwargs (letting websockets use its default)
+        call_args = mock_connect.call_args
+        assert "compression" not in call_args.kwargs
+
+    @pytest.mark.asyncio
+    @patch("websockets.connect", new_callable=AsyncMock)
+    async def test_compression_disabled_connect_kwargs(self, mock_connect: AsyncMock):
+        """Test that compression disabled adds compression=None to kwargs."""
+        mock_ws_connection = AsyncMock()
+        mock_ws_connection.state = State.OPEN
+        mock_connect.return_value = mock_ws_connection
+
+        ws_client = ParadexWebsocketClient(env=TESTNET, enable_compression=False)
+        await ws_client.connect()
+
+        # Verify compression=None is passed to disable compression
+        call_args = mock_connect.call_args
+        assert call_args.kwargs["compression"] is None
+
+    @pytest.mark.asyncio
+    @patch("websockets.connect", new_callable=AsyncMock)
+    async def test_compression_with_custom_connector(self, mock_connect: AsyncMock):
+        """Test that custom connector is unaffected by compression setting."""
+        mock_ws_connection = AsyncMock()
+        mock_ws_connection.state = State.OPEN
+
+        # Custom connector function
+        async def custom_connector(url: str, headers: dict) -> AsyncMock:
+            return mock_ws_connection
+
+        ws_client = ParadexWebsocketClient(env=TESTNET, connector=custom_connector, enable_compression=False)
+        await ws_client.connect()
+
+        # Custom connector should be used, not websockets.connect
+        mock_connect.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("websockets.connect", new_callable=AsyncMock)
+    async def test_compression_persists_after_reconnect(self, mock_connect: AsyncMock):
+        """Test that compression setting persists after reconnection."""
+        mock_ws_connection = AsyncMock()
+        mock_ws_connection.state = State.OPEN
+        mock_connect.return_value = mock_ws_connection
+
+        ws_client = ParadexWebsocketClient(env=TESTNET, enable_compression=False)
+
+        # First connection
+        await ws_client.connect()
+        first_call_args = mock_connect.call_args
+        assert first_call_args.kwargs["compression"] is None
+
+        # Simulate reconnection
+        mock_connect.reset_mock()
+        mock_ws_connection.state = State.OPEN
+        mock_connect.return_value = mock_ws_connection
+
+        with patch.object(ws_client, "_send_auth_id", new_callable=AsyncMock):
+            await ws_client._reconnect()
+
+        # Verify compression setting persists after reconnect
+        if mock_connect.called:
+            second_call_args = mock_connect.call_args
+            assert second_call_args.kwargs["compression"] is None
+
+    def test_compression_disabled_via_paradex_constructor(self):
+        """Test that compression can be disabled via Paradex constructor."""
+        paradex = Paradex(env=TESTNET, enable_ws_compression=False)
+
+        # Should have created a WebSocket client with compression disabled
+        assert paradex.ws_client.enable_compression is False
+
+    def test_compression_enabled_via_paradex_constructor(self):
+        """Test that compression is enabled via Paradex constructor."""
+        paradex = Paradex(env=TESTNET, enable_ws_compression=True)
+
+        # Should have created a WebSocket client with compression enabled
+        assert paradex.ws_client.enable_compression is True
+
+    def test_compression_default_via_paradex_constructor(self):
+        """Test that compression is enabled by default via Paradex constructor."""
+        paradex = Paradex(env=TESTNET)
+
+        # Should use default compression behavior (enabled)
+        assert paradex.ws_client.enable_compression is True
+
+    def test_compression_with_other_ws_options(self):
+        """Test that compression works alongside other WebSocket options."""
+        ws_client = ParadexWebsocketClient(
+            env=TESTNET, enable_compression=False, ws_timeout=30, ping_interval=20.0, disable_reconnect=True
+        )
+
+        # Should have all options set correctly
+        assert ws_client.enable_compression is False
+        assert ws_client.ws_timeout == 30
+        assert ws_client.ping_interval == 20.0
+        assert ws_client.disable_reconnect is True
+
+    @pytest.mark.asyncio
+    @patch("websockets.connect", new_callable=AsyncMock)
+    async def test_compression_with_ping_interval(self, mock_connect: AsyncMock):
+        """Test that compression works alongside ping_interval configuration."""
+        mock_ws_connection = AsyncMock()
+        mock_ws_connection.state = State.OPEN
+        mock_connect.return_value = mock_ws_connection
+
+        ws_client = ParadexWebsocketClient(env=TESTNET, enable_compression=False, ping_interval=15.0)
+        await ws_client.connect()
+
+        # Verify both compression and ping_interval are passed
+        call_args = mock_connect.call_args
+        assert call_args.kwargs["compression"] is None
+        assert call_args.kwargs["ping_interval"] == 15


### PR DESCRIPTION
Add configurable compression support for HTTP and WebSocket clients to reduce bandwidth usage.

**Changes:**
- Add `enable_http_compression` and `enable_ws_compression` parameters to Paradex constructor (default: true)
- Backward compatible - compression enabled by default
- 22 new tests, verified against production API

**Usage:**
```python
# Disable compression for debugging
paradex = Paradex(env=TESTNET, enable_http_compression=False, enable_ws_compression=False)
```