### PR TITLE
Add WebSocket order management with Cancel-on-Disconnect support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,12 @@ Full details for REST API & WebSocket JSON-RPC API can be found at the following
       show_source: false
       show_root_heading: true
 
+::: paradex_py.api.ws_client.WsRpcError
+    handler: python
+    options:
+      show_source: false
+      show_root_heading: true
+
 ::: paradex_py.api.ws_client.ParadexWebsocketClient
     handler: python
     options:

--- a/examples/ws_order_management.py
+++ b/examples/ws_order_management.py
@@ -1,0 +1,116 @@
+"""WebSocket order management example with Cancel-on-Disconnect.
+
+This example shows how to submit, modify, and cancel orders over a persistent
+WebSocket connection instead of the REST API, and how to arm Cancel-on-Disconnect
+so open orders are automatically cancelled if the connection drops.
+
+Key differences from REST:
+  - All order methods are async and use the same connection as subscriptions.
+  - Cancel-on-Disconnect (CoD) is session-scoped and OFF by default; call
+    ``cancel_on_disconnect(True)`` after each (re)connect to arm it.
+  - WsRpcError is raised when the server rejects a request (instead of httpx errors).
+
+Usage:
+    L1_ADDRESS=0x... L1_PRIVATE_KEY=0x... python examples/ws_order_management.py
+"""
+
+import asyncio
+import logging
+import os
+from decimal import Decimal
+
+from paradex_py import Paradex
+from paradex_py.api.ws_client import ParadexWebsocketChannel, WsRpcError
+from paradex_py.common.order import Order, OrderSide, OrderType
+from paradex_py.environment import TESTNET
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+L1_ADDRESS = os.environ["L1_ADDRESS"]
+L1_PRIVATE_KEY = os.environ["L1_PRIVATE_KEY"]
+
+MARKET = "ETH-USD-PERP"
+
+
+async def on_order_update(ws_channel: ParadexWebsocketChannel, message: dict) -> None:
+    data = message.get("params", {}).get("data", {})
+    logger.info(f"Order update: id={data.get('id')} status={data.get('status')} market={data.get('market')}")
+
+
+async def main() -> None:
+    paradex = Paradex(env=TESTNET, l1_address=L1_ADDRESS, l1_private_key=L1_PRIVATE_KEY)
+    ws = paradex.ws_client
+
+    # Connect and authenticate
+    connected = await ws.connect()
+    if not connected:
+        raise RuntimeError("WebSocket connection failed")
+    logger.info("Connected")
+
+    # Subscribe to order updates so we see fills and status changes
+    await ws.subscribe(ParadexWebsocketChannel.ORDERS, on_order_update, params={"market": "ALL"})
+
+    # Arm Cancel-on-Disconnect for this session.
+    # CoD is OFF by default and resets on every reconnect — re-enable after reconnects
+    # if your application requires it.
+    cod_result = await ws.cancel_on_disconnect(True)
+    logger.info(f"Cancel-on-Disconnect enabled: {cod_result['enabled']}")
+
+    # --- Submit a limit order ---
+    order = Order(
+        market=MARKET,
+        order_type=OrderType.Limit,
+        order_side=OrderSide.Buy,
+        size=Decimal("0.01"),
+        limit_price=Decimal("1000"),  # well below market — won't fill
+        instruction="GTC",
+    )
+    try:
+        result = await ws.submit_order(order)
+        order_id = result["order"]["id"]
+        logger.info(f"Order created: id={order_id}")
+    except WsRpcError as e:
+        logger.error(f"submit_order failed: {e}")
+        return
+
+    # --- Modify the order (lower the price) ---
+    modify_order = Order(
+        market=MARKET,
+        order_type=OrderType.Limit,
+        order_side=OrderSide.Buy,
+        size=Decimal("0.01"),
+        limit_price=Decimal("999"),
+        instruction="GTC",
+        order_id=order_id,
+    )
+    try:
+        mod_result = await ws.modify_order(order_id, modify_order)
+        logger.info(f"Order modified: id={mod_result['order']['id']}")
+    except WsRpcError as e:
+        logger.error(f"modify_order failed: {e}")
+
+    # --- Cancel the order by ID ---
+    try:
+        cancel_result = await ws.cancel_order(order_id)
+        logger.info(f"Order cancelled: {cancel_result}")
+    except WsRpcError as e:
+        logger.error(f"cancel_order failed: {e}")
+
+    # --- Demonstrate cancel_all_orders (no-op if no open orders remain) ---
+    try:
+        all_result = await ws.cancel_all_orders(market=MARKET)
+        logger.info(f"cancel_all_orders: {all_result}")
+    except WsRpcError as e:
+        logger.error(f"cancel_all_orders failed: {e}")
+
+    # --- Disarm CoD before clean shutdown so the close doesn't trigger cancellations ---
+    await ws.cancel_on_disconnect(False)
+    logger.info("Cancel-on-Disconnect disabled")
+
+    await ws.close()
+    logger.info("Disconnected")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/paradex_py/api/ws_client.py
+++ b/paradex_py/api/ws_client.py
@@ -14,9 +14,22 @@ from pydantic import BaseModel
 from websockets import ClientConnection, State
 
 from paradex_py.account.account import ParadexAccount
+from paradex_py.api.protocols import Signer
+from paradex_py.common.order import Order
 from paradex_py.constants import WS_TIMEOUT
 from paradex_py.environment import Environment
 from paradex_py.user_agent import get_user_agent
+
+
+class WsRpcError(Exception):
+    """Raised when a WebSocket JSON-RPC response contains an error."""
+
+    def __init__(self, error: dict):
+        self.code = error.get("code")
+        self.message = error.get("message", "")
+        self.data = error.get("data")
+        super().__init__(f"WS RPC error {self.code}: {self.message}")
+
 
 # Optional typed message models
 try:
@@ -198,6 +211,9 @@ class ParadexWebsocketClient:
         # Lock to synchronize WebSocket recv() calls between background reader and manual pump_once
         self._recv_lock = asyncio.Lock()
 
+        # Pending request-response futures keyed by JSON-RPC id
+        self._pending_requests: dict[int, asyncio.Future] = {}
+
         # Configurable sleep durations for simulator-friendly behavior
         self.reader_sleep_on_error = reader_sleep_on_error
         self.reader_sleep_on_no_connection = reader_sleep_on_no_connection
@@ -338,6 +354,10 @@ class ParadexWebsocketClient:
             # Set flag to prevent reconnection during intentional closure
             self._is_closing = True
 
+            # Fail any in-flight request-response futures immediately so callers
+            # get a ConnectionError rather than waiting for their timeout.
+            self._cancel_pending_requests(ConnectionError("WebSocket connection closed"))
+
             # Cancel reader task if it exists
             if self._reader_task and not self._reader_task.done():
                 self._reader_task.cancel()
@@ -356,6 +376,13 @@ class ParadexWebsocketClient:
         finally:
             # Reset flag after closing is complete
             self._is_closing = False
+
+    def _cancel_pending_requests(self, exc: Exception) -> None:
+        """Fail all in-flight request futures with *exc* and clear the pending map."""
+        for future in self._pending_requests.values():
+            if not future.done():
+                future.set_exception(exc)
+        self._pending_requests.clear()
 
     def _decode_jwt_payload(self, token: str) -> dict[str, Any] | None:
         """Decode JWT token payload without signature verification.
@@ -474,6 +501,14 @@ class ParadexWebsocketClient:
 
     def _check_subscribed_channel(self, message: dict) -> None:
         if "id" in message:
+            # Resolve pending request-response futures first
+            msg_id = message.get("id")
+            if msg_id in self._pending_requests:
+                future = self._pending_requests.pop(msg_id)
+                if not future.done():
+                    future.set_result(message)
+                return
+
             # Check for successful subscription
             channel_subscribed: str | None = message.get("result", {}).get("channel")
             if channel_subscribed:
@@ -885,3 +920,216 @@ class ParadexWebsocketClient:
                 }
             )
         )
+
+    # -------------------------------------------------------------------------
+    # Request-response plumbing
+    # -------------------------------------------------------------------------
+
+    async def _send_request(self, method: str, params: Any, timeout: float = 10.0) -> dict:
+        """Send a JSON-RPC request and wait for the server's response.
+
+        Args:
+            method: JSON-RPC method name (e.g. "order.create").
+            params: Request parameters — dict or list depending on the method.
+            timeout: Seconds to wait for a response before raising TimeoutError.
+
+        Returns:
+            The ``result`` field from the server response.
+
+        Raises:
+            WsRpcError: If the server returns an error response.
+            asyncio.TimeoutError: If no response arrives within *timeout* seconds.
+        """
+        msg_id = int(time.time() * 1_000_000)
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future = loop.create_future()
+        self._pending_requests[msg_id] = future
+        try:
+            await self._send(
+                json.dumps(
+                    {
+                        "id": msg_id,
+                        "jsonrpc": "2.0",
+                        "method": method,
+                        "params": params,
+                    }
+                )
+            )
+            response = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+        except asyncio.TimeoutError:
+            self._pending_requests.pop(msg_id, None)
+            raise
+        if "error" in response:
+            raise WsRpcError(response["error"])
+        return response.get("result", {})
+
+    # -------------------------------------------------------------------------
+    # Order management — mirrors paradex_py.api.api_client interface
+    # -------------------------------------------------------------------------
+
+    def _resolve_order_params(self, order: Order, signer: Signer | None) -> dict:
+        """Sign the order and return the payload dict."""
+        if signer is not None:
+            return signer.sign_order(order.dump_to_dict())
+        if self.account is not None:
+            order.signature = self.account.sign_order(order)
+            return order.dump_to_dict()
+        raise ValueError("Account not initialized and no signer provided")
+
+    async def submit_order(self, order: Order, signer: Signer | None = None) -> dict:
+        """Create an order over WebSocket (``order.create``).
+
+        Mirrors :meth:`paradex_py.api.api_client.ParadexApiClient.submit_order`.
+        The connection must be authenticated before calling this method.
+
+        Args:
+            order: Order to submit.
+            signer: Optional custom signer. Falls back to the account signer.
+
+        Returns:
+            Server result dict containing ``order``, ``created_at``, ``received_at``.
+
+        Raises:
+            WsRpcError: If the server rejects the order.
+        """
+        params = self._resolve_order_params(order, signer)
+        return await self._send_request("order.create", params)
+
+    async def submit_orders_batch(self, orders: list[Order], signer: Signer | None = None) -> dict:
+        """Create a batch of orders over WebSocket (``order.create_batch``).
+
+        Args:
+            orders: Orders to submit.
+            signer: Optional custom signer. Falls back to the account signer.
+
+        Returns:
+            Server result dict containing per-order outcomes.
+
+        Raises:
+            WsRpcError: If the server rejects the batch.
+        """
+        params = [self._resolve_order_params(order, signer) for order in orders]
+        return await self._send_request("order.create_batch", params)
+
+    async def modify_order(self, order_id: str, order: Order, signer: Signer | None = None) -> dict:
+        """Modify an open order over WebSocket (``order.modify``).
+
+        Mirrors :meth:`paradex_py.api.api_client.ParadexApiClient.modify_order`.
+
+        Args:
+            order_id: ID of the order to modify.
+            order: Order object carrying the updated fields and a fresh signature.
+            signer: Optional custom signer. Falls back to the account signer.
+
+        Returns:
+            Server result dict containing the updated ``order``.
+
+        Raises:
+            WsRpcError: If the server rejects the modification.
+        """
+        params = self._resolve_order_params(order, signer)
+        params["id"] = order_id
+        return await self._send_request("order.modify", params)
+
+    async def cancel_order(self, order_id: str) -> dict:
+        """Cancel an order by ID over WebSocket (``order.cancel``).
+
+        Mirrors :meth:`paradex_py.api.api_client.ParadexApiClient.cancel_order`.
+
+        Args:
+            order_id: Paradex-assigned order ID.
+
+        Returns:
+            Server result dict containing ``order_id`` and ``status``.
+
+        Raises:
+            WsRpcError: If the order cannot be cancelled.
+        """
+        return await self._send_request("order.cancel", {"id": order_id})
+
+    async def cancel_order_by_client_id(self, client_id: str, market: str) -> dict:
+        """Cancel an order by client ID over WebSocket (``order.cancel``).
+
+        Mirrors :meth:`paradex_py.api.api_client.ParadexApiClient.cancel_order_by_client_id`.
+
+        Args:
+            client_id: Trader-assigned client order ID.
+            market: Market the order belongs to (required by the server).
+
+        Returns:
+            Server result dict containing ``order_id`` and ``status``.
+
+        Raises:
+            WsRpcError: If the order cannot be cancelled.
+        """
+        return await self._send_request("order.cancel", {"client_id": client_id, "market": market})
+
+    async def cancel_all_orders(self, market: str | None = None) -> dict:
+        """Cancel all open orders over WebSocket (``order.cancel_all``).
+
+        Mirrors :meth:`paradex_py.api.api_client.ParadexApiClient.cancel_all_orders`.
+
+        Args:
+            market: If provided, cancel only orders in this market.
+
+        Returns:
+            Server result dict containing ``status``.
+
+        Raises:
+            WsRpcError: On server-side error.
+        """
+        params: dict = {}
+        if market:
+            params["market"] = market
+        return await self._send_request("order.cancel_all", params)
+
+    async def cancel_orders_batch(self, order_ids: list[str]) -> dict:
+        """Cancel a batch of orders by ID over WebSocket (``order.cancel_batch``).
+
+        Mirrors :meth:`paradex_py.api.api_client.ParadexApiClient.cancel_orders_batch`.
+
+        Args:
+            order_ids: List of Paradex-assigned order IDs to cancel.
+
+        Returns:
+            Server result dict containing per-order cancellation outcomes.
+
+        Raises:
+            WsRpcError: On server-side error.
+        """
+        return await self._send_request("order.cancel_batch", {"order_ids": order_ids})
+
+    async def cancel_on_disconnect(self, enabled: bool) -> dict:
+        """Toggle Cancel-on-Disconnect for this WebSocket session (``order.cancel_on_disconnect``).
+
+        **Off by default.** Each new WebSocket session starts with CoD disabled.
+        Call ``cancel_on_disconnect(True)`` after connecting and authenticating to
+        arm it for the session.
+
+        When enabled, the server automatically cancels all orders that were submitted
+        via this session if the WebSocket connection drops. The tracking set is
+        managed entirely server-side and is scoped to the current connection — it
+        resets on every reconnect, so re-enable CoD after each reconnect if needed.
+
+        Args:
+            enabled: ``True`` to enable CoD, ``False`` to disable.
+
+        Returns:
+            Server result dict containing ``enabled`` confirming the new state.
+
+        Raises:
+            WsRpcError: If the server rejects the request.
+
+        Examples:
+            >>> async def main():
+            ...     paradex = Paradex(env=TESTNET, l1_address="0x...", l1_private_key="0x...")
+            ...     await paradex.ws_client.connect()
+            ...     # Arm cancel-on-disconnect for this session
+            ...     await paradex.ws_client.cancel_on_disconnect(True)
+            ...     # Orders submitted now will be cancelled if the connection drops
+            ...     order = Order(market="BTC-USD-PERP", ...)
+            ...     result = await paradex.ws_client.submit_order(order)
+            ...     # Disable CoD when no longer needed
+            ...     await paradex.ws_client.cancel_on_disconnect(False)
+        """
+        return await self._send_request("order.cancel_on_disconnect", {"enabled": enabled})

--- a/paradex_py/api/ws_client.py
+++ b/paradex_py/api/ws_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import itertools
 import json
 import logging
 import time
@@ -19,6 +20,7 @@ from paradex_py.common.order import Order
 from paradex_py.constants import WS_TIMEOUT
 from paradex_py.environment import Environment
 from paradex_py.user_agent import get_user_agent
+from paradex_py.utils import time_now_micro_secs
 
 
 class WsRpcError(Exception):
@@ -213,6 +215,7 @@ class ParadexWebsocketClient:
 
         # Pending request-response futures keyed by JSON-RPC id
         self._pending_requests: dict[int, asyncio.Future] = {}
+        self._next_request_id = itertools.count(1)
 
         # Configurable sleep durations for simulator-friendly behavior
         self.reader_sleep_on_error = reader_sleep_on_error
@@ -491,7 +494,7 @@ class ParadexWebsocketClient:
         await websocket.send(
             json.dumps(
                 {
-                    "id": int(time.time() * 1_000_000),
+                    "id": time_now_micro_secs(),
                     "jsonrpc": "2.0",
                     "method": "auth",
                     "params": {"bearer": paradex_jwt},
@@ -502,7 +505,7 @@ class ParadexWebsocketClient:
     def _check_subscribed_channel(self, message: dict) -> None:
         if "id" in message:
             # Resolve pending request-response futures first
-            msg_id = message.get("id")
+            msg_id = message["id"]
             if msg_id in self._pending_requests:
                 future = self._pending_requests.pop(msg_id)
                 if not future.done():
@@ -841,7 +844,7 @@ class ParadexWebsocketClient:
             "jsonrpc": "2.0",
             "method": "unsubscribe",
             "params": {"channel": channel_name},
-            "id": str(int(time.time() * 1_000_000)),
+            "id": str(time_now_micro_secs()),
         }
         await self._send(json.dumps(unsubscribe_message))
 
@@ -913,7 +916,7 @@ class ParadexWebsocketClient:
         await self._send(
             json.dumps(
                 {
-                    "id": int(time.time() * 1_000_000),
+                    "id": time_now_micro_secs(),
                     "jsonrpc": "2.0",
                     "method": "subscribe",
                     "params": {"channel": channel_name},
@@ -940,9 +943,8 @@ class ParadexWebsocketClient:
             WsRpcError: If the server returns an error response.
             asyncio.TimeoutError: If no response arrives within *timeout* seconds.
         """
-        msg_id = int(time.time() * 1_000_000)
-        loop = asyncio.get_event_loop()
-        future: asyncio.Future = loop.create_future()
+        msg_id = next(self._next_request_id)
+        future: asyncio.Future[dict] = asyncio.get_running_loop().create_future()
         self._pending_requests[msg_id] = future
         try:
             await self._send(
@@ -955,7 +957,7 @@ class ParadexWebsocketClient:
                     }
                 )
             )
-            response = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+            response = await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
             self._pending_requests.pop(msg_id, None)
             raise

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1,6 +1,8 @@
 from starknet_py.common import int_from_hex
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 from paradex_py.account.account import ParadexAccount
+from paradex_py.account.subkey_account import SubkeyAccount
 from paradex_py.account.utils import typed_data_to_message_hash, unflatten_signature, verify_message_signature
 from paradex_py.message.auth import build_auth_message
 from paradex_py.message.onboarding import build_onboarding_message
@@ -11,6 +13,9 @@ TEST_L1_PRIVATE_KEY = "0xf8e4d1d772cdd44e5e77615ad11cc071c94e4c06dc21150d903f28e
 TEST_L2_ADDRESS = int_from_hex("0x129c135ed63df9353885e292be4426b8ed6122b13c6c0e1bb787288a1f5adfa")
 TEST_L2_PRIVATE_KEY = "0x543b6cf6c91817a87174aaea4fb370ac1c694e864d7740d728f8344d53e815"
 TEST_L2_PUBLIC_KEY = int_from_hex("0x2c144d2f2d4fc61b6f8967f3ba0012a87d90140bcfe5a3e92e8df83258c960f")
+
+# A distinct private key used as a subkey (different from the main account key)
+TEST_SUBKEY_PRIVATE_KEY = "0x1a2b3c4d5e6f"
 
 
 def test_account_l1_private_key():
@@ -89,3 +94,93 @@ def test_account_auth_signature():
         account.l2_public_key,
     )
     assert is_signature_valid is True
+
+
+# ---------------------------------------------------------------------------
+# SubkeyAccount: explicit address + l2 key (ParadexL2 scenario)
+# ---------------------------------------------------------------------------
+
+
+def test_subkey_account_with_main_l2_key_address_is_preserved():
+    """SubkeyAccount must use the provided address, not derive it from the key."""
+    config = MockApiClient().fetch_system_config()
+
+    account = SubkeyAccount(
+        config=config,
+        l2_private_key=TEST_L2_PRIVATE_KEY,
+        l2_address=hex(TEST_L2_ADDRESS),
+    )
+
+    assert account.l2_address == TEST_L2_ADDRESS
+    assert account.starknet.address == TEST_L2_ADDRESS
+    assert account.l2_public_key == TEST_L2_PUBLIC_KEY
+
+
+def test_subkey_account_with_main_l2_key_auth_signature():
+    """Auth signature from SubkeyAccount (main l2 key) is verifiable with account's public key."""
+    config = MockApiClient().fetch_system_config()
+
+    account = SubkeyAccount(
+        config=config,
+        l2_private_key=TEST_L2_PRIVATE_KEY,
+        l2_address=hex(TEST_L2_ADDRESS),
+    )
+
+    timestamp = 1706868900
+    expiry = 1706955300
+    sig = account.auth_signature(timestamp, expiry)
+
+    message = build_auth_message(account.l2_chain_id, timestamp, expiry)
+    assert verify_message_signature(
+        typed_data_to_message_hash(message, account.l2_address),
+        unflatten_signature(sig),
+        account.l2_public_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SubkeyAccount: explicit address + subkey (ParadexSubkey scenario)
+# ---------------------------------------------------------------------------
+
+
+def test_subkey_account_with_subkey_uses_main_account_address():
+    """SubkeyAccount with a subkey must use the provided main account address."""
+    config = MockApiClient().fetch_system_config()
+    subkey_pair = KeyPair.from_private_key(int_from_hex(TEST_SUBKEY_PRIVATE_KEY))
+
+    account = SubkeyAccount(
+        config=config,
+        l2_private_key=TEST_SUBKEY_PRIVATE_KEY,
+        l2_address=hex(TEST_L2_ADDRESS),  # main account address, not derived from subkey
+    )
+
+    assert account.l2_address == TEST_L2_ADDRESS
+    assert account.starknet.address == TEST_L2_ADDRESS
+    # Public key should belong to the subkey, not the main account
+    assert account.l2_public_key == subkey_pair.public_key
+    assert account.l2_public_key != TEST_L2_PUBLIC_KEY
+
+
+def test_subkey_account_with_subkey_auth_signature():
+    """Auth signature from SubkeyAccount (subkey) is verifiable with the subkey's public key."""
+    config = MockApiClient().fetch_system_config()
+    subkey_pair = KeyPair.from_private_key(int_from_hex(TEST_SUBKEY_PRIVATE_KEY))
+
+    account = SubkeyAccount(
+        config=config,
+        l2_private_key=TEST_SUBKEY_PRIVATE_KEY,
+        l2_address=hex(TEST_L2_ADDRESS),  # main account address
+    )
+
+    timestamp = 1706868900
+    expiry = 1706955300
+    sig = account.auth_signature(timestamp, expiry)
+
+    # The message hash uses the main account address (as seen by Paradex),
+    # but the signature is produced by the subkey's private key.
+    message = build_auth_message(account.l2_chain_id, timestamp, expiry)
+    assert verify_message_signature(
+        typed_data_to_message_hash(message, account.l2_address),
+        unflatten_signature(sig),
+        subkey_pair.public_key,  # verified with subkey's public key
+    )

--- a/tests/api/test_ws_orders.py
+++ b/tests/api/test_ws_orders.py
@@ -58,6 +58,27 @@ def _inject_response(
     future.set_result(response)
 
 
+async def _run_with_response(
+    ws_client: ParadexWebsocketClient,
+    coro,
+    *,
+    result: dict | None = None,
+    error: dict | None = None,
+):
+    """Run *coro* while auto-injecting a server response for the first pending request."""
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result=result, error=error)
+
+    task = asyncio.create_task(inject())
+    ret = await coro
+    await task
+    return ret
+
+
 # ---------------------------------------------------------------------------
 # WsRpcError
 # ---------------------------------------------------------------------------
@@ -92,16 +113,7 @@ async def test_send_request_success():
 
     result_payload = {"status": "ok"}
 
-    async def inject():
-        # Wait until the request is registered then resolve it
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result=result_payload)
-
-    task = asyncio.create_task(inject())
-    result = await ws_client._send_request("order.cancel_all", {})
-    await task
+    result = await _run_with_response(ws_client, ws_client._send_request("order.cancel_all", {}), result=result_payload)
 
     assert result == result_payload
     assert len(sent) == 1
@@ -117,16 +129,12 @@ async def test_send_request_raises_ws_rpc_error_on_error_response():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, error={"code": 400, "message": "bad request"})
-
-    task = asyncio.create_task(inject())
     with pytest.raises(WsRpcError) as exc_info:
-        await ws_client._send_request("order.create", {})
-    await task
+        await _run_with_response(
+            ws_client,
+            ws_client._send_request("order.create", {}),
+            error={"code": 400, "message": "bad request"},
+        )
 
     assert exc_info.value.code == 400
 
@@ -197,15 +205,7 @@ async def test_submit_order_with_account():
     order = _make_order()
     server_result = {"order": {"id": "srv-id"}, "created_at": 1000, "received_at": 2000}
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result=server_result)
-
-    task = asyncio.create_task(inject())
-    result = await ws_client.submit_order(order)
-    await task
+    result = await _run_with_response(ws_client, ws_client.submit_order(order), result=server_result)
 
     assert result == server_result
     sent_msg = json.loads(sent[0])
@@ -225,15 +225,7 @@ async def test_submit_order_with_signer():
 
     order = _make_order()
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"order": {}})
-
-    task = asyncio.create_task(inject())
-    await ws_client.submit_order(order, signer=mock_signer)
-    await task
+    await _run_with_response(ws_client, ws_client.submit_order(order, signer=mock_signer), result={"order": {}})
 
     mock_signer.sign_order.assert_called_once()
 
@@ -258,15 +250,9 @@ async def test_cancel_order_sends_correct_params():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"order_id": "abc", "status": "cancelled"})
-
-    task = asyncio.create_task(inject())
-    result = await ws_client.cancel_order("abc")
-    await task
+    result = await _run_with_response(
+        ws_client, ws_client.cancel_order("abc"), result={"order_id": "abc", "status": "cancelled"}
+    )
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.cancel"
@@ -285,15 +271,11 @@ async def test_cancel_order_by_client_id_sends_correct_params():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"order_id": "abc", "status": "cancelled"})
-
-    task = asyncio.create_task(inject())
-    await ws_client.cancel_order_by_client_id("my-id", "BTC-USD-PERP")
-    await task
+    await _run_with_response(
+        ws_client,
+        ws_client.cancel_order_by_client_id("my-id", "BTC-USD-PERP"),
+        result={"order_id": "abc", "status": "cancelled"},
+    )
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.cancel"
@@ -311,15 +293,7 @@ async def test_cancel_all_orders_no_market():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"status": "ok"})
-
-    task = asyncio.create_task(inject())
-    result = await ws_client.cancel_all_orders()
-    await task
+    result = await _run_with_response(ws_client, ws_client.cancel_all_orders(), result={"status": "ok"})
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.cancel_all"
@@ -333,15 +307,7 @@ async def test_cancel_all_orders_with_market():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"status": "ok"})
-
-    task = asyncio.create_task(inject())
-    await ws_client.cancel_all_orders(market="ETH-USD-PERP")
-    await task
+    await _run_with_response(ws_client, ws_client.cancel_all_orders(market="ETH-USD-PERP"), result={"status": "ok"})
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["params"] == {"market": "ETH-USD-PERP"}
@@ -360,15 +326,7 @@ async def test_cancel_orders_batch_sends_correct_params():
 
     order_ids = ["id1", "id2", "id3"]
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"results": []})
-
-    task = asyncio.create_task(inject())
-    await ws_client.cancel_orders_batch(order_ids)
-    await task
+    await _run_with_response(ws_client, ws_client.cancel_orders_batch(order_ids), result={"results": []})
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.cancel_batch"
@@ -392,15 +350,7 @@ async def test_modify_order_includes_order_id_in_params():
 
     order = _make_order()
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"order": {}})
-
-    task = asyncio.create_task(inject())
-    await ws_client.modify_order("existing-id", order)
-    await task
+    await _run_with_response(ws_client, ws_client.modify_order("existing-id", order), result={"order": {}})
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.modify"
@@ -418,15 +368,7 @@ async def test_cancel_on_disconnect_enable():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"enabled": True})
-
-    task = asyncio.create_task(inject())
-    result = await ws_client.cancel_on_disconnect(True)
-    await task
+    result = await _run_with_response(ws_client, ws_client.cancel_on_disconnect(True), result={"enabled": True})
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.cancel_on_disconnect"
@@ -440,15 +382,7 @@ async def test_cancel_on_disconnect_disable():
     sent: list[str] = []
     ws_client.ws = _make_open_ws(sent)
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"enabled": False})
-
-    task = asyncio.create_task(inject())
-    result = await ws_client.cancel_on_disconnect(False)
-    await task
+    result = await _run_with_response(ws_client, ws_client.cancel_on_disconnect(False), result={"enabled": False})
 
     assert result["enabled"] is False
 
@@ -470,15 +404,7 @@ async def test_submit_orders_batch_signs_each_order():
 
     orders = [_make_order(), _make_order()]
 
-    async def inject():
-        while not ws_client._pending_requests:
-            await asyncio.sleep(0)
-        msg_id = next(iter(ws_client._pending_requests))
-        _inject_response(ws_client, msg_id, result={"results": []})
-
-    task = asyncio.create_task(inject())
-    await ws_client.submit_orders_batch(orders)
-    await task
+    await _run_with_response(ws_client, ws_client.submit_orders_batch(orders), result={"results": []})
 
     sent_msg = json.loads(sent[0])
     assert sent_msg["method"] == "order.create_batch"

--- a/tests/api/test_ws_orders.py
+++ b/tests/api/test_ws_orders.py
@@ -1,0 +1,653 @@
+"""Tests for WebSocket order management methods on ParadexWebsocketClient."""
+
+import asyncio
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from paradex_py.api.ws_client import ParadexWebsocketClient, WsRpcError
+from paradex_py.common.order import Order, OrderSide, OrderType
+from paradex_py.environment import TESTNET
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_client() -> ParadexWebsocketClient:
+    """Create a ws_client with auto_start_reader=False to avoid background tasks."""
+    return ParadexWebsocketClient(env=TESTNET, auto_start_reader=False)
+
+
+def _make_open_ws(sent: list[str]) -> MagicMock:
+    """Return a mock WebSocket that records sent messages."""
+    from websockets import State
+
+    ws = MagicMock()
+    ws.state = State.OPEN
+    ws.send = AsyncMock(side_effect=lambda msg: sent.append(msg))
+    return ws
+
+
+def _make_order(order_id: str | None = None) -> Order:
+    return Order(
+        market="BTC-USD-PERP",
+        order_type=OrderType.Limit,
+        order_side=OrderSide.Buy,
+        size=Decimal("0.1"),
+        limit_price=Decimal("50000"),
+        client_id="test-client-id",
+        order_id=order_id,
+    )
+
+
+def _inject_response(
+    ws_client: ParadexWebsocketClient, msg_id: int, result: dict | None = None, error: dict | None = None
+) -> None:
+    """Resolve the pending future for *msg_id* as if the server replied."""
+    future = ws_client._pending_requests.get(msg_id)
+    if future is None or future.done():
+        return
+    response: dict = {"id": msg_id, "jsonrpc": "2.0"}
+    if error is not None:
+        response["error"] = error
+    else:
+        response["result"] = result or {}
+    future.set_result(response)
+
+
+# ---------------------------------------------------------------------------
+# WsRpcError
+# ---------------------------------------------------------------------------
+
+
+def test_ws_rpc_error_attributes():
+    err = WsRpcError({"code": 403, "message": "permission denied", "data": "extra"})
+    assert err.code == 403
+    assert err.message == "permission denied"
+    assert err.data == "extra"
+    assert "403" in str(err)
+    assert "permission denied" in str(err)
+
+
+def test_ws_rpc_error_missing_fields():
+    err = WsRpcError({})
+    assert err.code is None
+    assert err.message == ""
+    assert err.data is None
+
+
+# ---------------------------------------------------------------------------
+# _send_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_request_success():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    result_payload = {"status": "ok"}
+
+    async def inject():
+        # Wait until the request is registered then resolve it
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result=result_payload)
+
+    task = asyncio.create_task(inject())
+    result = await ws_client._send_request("order.cancel_all", {})
+    await task
+
+    assert result == result_payload
+    assert len(sent) == 1
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.cancel_all"
+    assert sent_msg["jsonrpc"] == "2.0"
+    assert "id" in sent_msg
+
+
+@pytest.mark.asyncio
+async def test_send_request_raises_ws_rpc_error_on_error_response():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, error={"code": 400, "message": "bad request"})
+
+    task = asyncio.create_task(inject())
+    with pytest.raises(WsRpcError) as exc_info:
+        await ws_client._send_request("order.create", {})
+    await task
+
+    assert exc_info.value.code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_request_timeout_cleans_up():
+    ws_client = _make_ws_client()
+    ws_client.ws = _make_open_ws([])
+
+    with pytest.raises(asyncio.TimeoutError):
+        await ws_client._send_request("order.create", {}, timeout=0.01)
+
+    # Future should be cleaned up after timeout
+    assert len(ws_client._pending_requests) == 0
+
+
+# ---------------------------------------------------------------------------
+# _check_subscribed_channel routes pending futures
+# ---------------------------------------------------------------------------
+
+
+def test_check_subscribed_channel_resolves_pending_future():
+    ws_client = _make_ws_client()
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        ws_client._pending_requests[42] = future
+
+        message = {"id": 42, "jsonrpc": "2.0", "result": {"order_id": "123", "status": "cancelled"}}
+        ws_client._check_subscribed_channel(message)
+
+        assert future.done()
+        assert future.result() == message
+        assert 42 not in ws_client._pending_requests
+    finally:
+        loop.close()
+
+
+def test_check_subscribed_channel_ignores_subscription_acks():
+    ws_client = _make_ws_client()
+    loop = asyncio.new_event_loop()
+    try:
+        # Subscription ack with no matching pending request
+        message = {"id": 999, "jsonrpc": "2.0", "result": {"channel": "orders.BTC-USD-PERP"}}
+        # Should not raise; pending_requests unchanged
+        ws_client._check_subscribed_channel(message)
+        assert len(ws_client._pending_requests) == 0
+        assert ws_client.subscribed_channels.get("orders.BTC-USD-PERP") is True
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# submit_order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_order_with_account():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    mock_account = MagicMock()
+    mock_account.sign_order.return_value = '["r","s"]'
+    ws_client.account = mock_account
+
+    order = _make_order()
+    server_result = {"order": {"id": "srv-id"}, "created_at": 1000, "received_at": 2000}
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result=server_result)
+
+    task = asyncio.create_task(inject())
+    result = await ws_client.submit_order(order)
+    await task
+
+    assert result == server_result
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.create"
+    assert sent_msg["params"]["market"] == "BTC-USD-PERP"
+    mock_account.sign_order.assert_called_once_with(order)
+
+
+@pytest.mark.asyncio
+async def test_submit_order_with_signer():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    mock_signer = MagicMock()
+    mock_signer.sign_order.return_value = {"market": "BTC-USD-PERP", "signature": "sig"}
+
+    order = _make_order()
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"order": {}})
+
+    task = asyncio.create_task(inject())
+    await ws_client.submit_order(order, signer=mock_signer)
+    await task
+
+    mock_signer.sign_order.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_order_raises_without_account_or_signer():
+    ws_client = _make_ws_client()
+    ws_client.ws = _make_open_ws([])
+
+    with pytest.raises(ValueError, match="Account not initialized"):
+        await ws_client.submit_order(_make_order())
+
+
+# ---------------------------------------------------------------------------
+# cancel_order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_sends_correct_params():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"order_id": "abc", "status": "cancelled"})
+
+    task = asyncio.create_task(inject())
+    result = await ws_client.cancel_order("abc")
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.cancel"
+    assert sent_msg["params"] == {"id": "abc"}
+    assert result["status"] == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# cancel_order_by_client_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_by_client_id_sends_correct_params():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"order_id": "abc", "status": "cancelled"})
+
+    task = asyncio.create_task(inject())
+    await ws_client.cancel_order_by_client_id("my-id", "BTC-USD-PERP")
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.cancel"
+    assert sent_msg["params"] == {"client_id": "my-id", "market": "BTC-USD-PERP"}
+
+
+# ---------------------------------------------------------------------------
+# cancel_all_orders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_orders_no_market():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"status": "ok"})
+
+    task = asyncio.create_task(inject())
+    result = await ws_client.cancel_all_orders()
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.cancel_all"
+    assert sent_msg["params"] == {}
+    assert result["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_orders_with_market():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"status": "ok"})
+
+    task = asyncio.create_task(inject())
+    await ws_client.cancel_all_orders(market="ETH-USD-PERP")
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["params"] == {"market": "ETH-USD-PERP"}
+
+
+# ---------------------------------------------------------------------------
+# cancel_orders_batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_orders_batch_sends_correct_params():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    order_ids = ["id1", "id2", "id3"]
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"results": []})
+
+    task = asyncio.create_task(inject())
+    await ws_client.cancel_orders_batch(order_ids)
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.cancel_batch"
+    assert sent_msg["params"] == {"order_ids": order_ids}
+
+
+# ---------------------------------------------------------------------------
+# modify_order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modify_order_includes_order_id_in_params():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    mock_account = MagicMock()
+    mock_account.sign_order.return_value = '["r","s"]'
+    ws_client.account = mock_account
+
+    order = _make_order()
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"order": {}})
+
+    task = asyncio.create_task(inject())
+    await ws_client.modify_order("existing-id", order)
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.modify"
+    assert sent_msg["params"]["id"] == "existing-id"
+
+
+# ---------------------------------------------------------------------------
+# cancel_on_disconnect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_on_disconnect_enable():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"enabled": True})
+
+    task = asyncio.create_task(inject())
+    result = await ws_client.cancel_on_disconnect(True)
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.cancel_on_disconnect"
+    assert sent_msg["params"] == {"enabled": True}
+    assert result["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_on_disconnect_disable():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"enabled": False})
+
+    task = asyncio.create_task(inject())
+    result = await ws_client.cancel_on_disconnect(False)
+    await task
+
+    assert result["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# submit_orders_batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_orders_batch_signs_each_order():
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    mock_account = MagicMock()
+    mock_account.sign_order.return_value = '["r","s"]'
+    ws_client.account = mock_account
+
+    orders = [_make_order(), _make_order()]
+
+    async def inject():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        msg_id = next(iter(ws_client._pending_requests))
+        _inject_response(ws_client, msg_id, result={"results": []})
+
+    task = asyncio.create_task(inject())
+    await ws_client.submit_orders_batch(orders)
+    await task
+
+    sent_msg = json.loads(sent[0])
+    assert sent_msg["method"] == "order.create_batch"
+    assert isinstance(sent_msg["params"], list)
+    assert len(sent_msg["params"]) == 2
+    assert mock_account.sign_order.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Reconnect / connection cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_pending_requests_sets_exception_on_all_futures():
+    """_cancel_pending_requests fails every in-flight future immediately."""
+    ws_client = _make_ws_client()
+    loop = asyncio.new_event_loop()
+    try:
+        f1 = loop.create_future()
+        f2 = loop.create_future()
+        ws_client._pending_requests[1] = f1
+        ws_client._pending_requests[2] = f2
+
+        exc = ConnectionError("WebSocket connection closed")
+        ws_client._cancel_pending_requests(exc)
+
+        assert f1.done() and f1.exception() is exc
+        assert f2.done() and f2.exception() is exc
+        assert ws_client._pending_requests == {}
+    finally:
+        loop.close()
+
+
+def test_cancel_pending_requests_skips_already_done_futures():
+    """_cancel_pending_requests does not raise on futures that are already resolved."""
+    ws_client = _make_ws_client()
+    loop = asyncio.new_event_loop()
+    try:
+        f = loop.create_future()
+        f.set_result({"result": {}})
+        ws_client._pending_requests[1] = f
+
+        ws_client._cancel_pending_requests(ConnectionError("closed"))
+        # Should not raise; future remains resolved (not overwritten)
+        assert f.result() == {"result": {}}
+        assert ws_client._pending_requests == {}
+    finally:
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_close_connection_cancels_pending_requests():
+    """Closing the connection immediately fails in-flight requests."""
+    ws_client = _make_ws_client()
+    ws_client.ws = _make_open_ws([])
+
+    loop = asyncio.get_event_loop()
+    future = loop.create_future()
+    ws_client._pending_requests[99] = future
+
+    await ws_client._close_connection()
+
+    assert future.done()
+    assert isinstance(future.exception(), ConnectionError)
+    assert ws_client._pending_requests == {}
+
+
+@pytest.mark.asyncio
+async def test_send_request_raises_connection_error_on_disconnect():
+    """A pending _send_request raises ConnectionError when the connection closes."""
+    ws_client = _make_ws_client()
+    ws_client.ws = _make_open_ws([])
+
+    async def close_during_request():
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        await ws_client._close_connection()
+
+    task = asyncio.create_task(close_during_request())
+    with pytest.raises(ConnectionError):
+        await ws_client._send_request("order.cancel_all", {}, timeout=5.0)
+    await task
+
+
+# ---------------------------------------------------------------------------
+# Concurrent requests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_resolved_independently():
+    """Multiple in-flight requests are each resolved with their own response."""
+    ws_client = _make_ws_client()
+    sent: list[str] = []
+    ws_client.ws = _make_open_ws(sent)
+
+    results: list[dict] = []
+
+    async def do_cancel(order_id: str) -> None:
+        result = await ws_client.cancel_order(order_id)
+        results.append(result)
+
+    # Start two concurrent cancels
+    t1 = asyncio.create_task(do_cancel("order-A"))
+    t2 = asyncio.create_task(do_cancel("order-B"))
+
+    # Wait until both requests are registered
+    while len(ws_client._pending_requests) < 2:
+        await asyncio.sleep(0)
+
+    ids = list(ws_client._pending_requests.keys())
+    # Deliver responses via _process_message so the full pop() path is exercised
+    await ws_client._process_message(
+        json.dumps({"id": ids[0], "jsonrpc": "2.0", "result": {"order_id": "order-A", "status": "cancelled"}})
+    )
+    await ws_client._process_message(
+        json.dumps({"id": ids[1], "jsonrpc": "2.0", "result": {"order_id": "order-B", "status": "cancelled"}})
+    )
+
+    await asyncio.gather(t1, t2)
+
+    assert len(results) == 2
+    statuses = {r["status"] for r in results}
+    assert statuses == {"cancelled"}
+    # Both futures consumed — no leaks
+    assert ws_client._pending_requests == {}
+
+
+# ---------------------------------------------------------------------------
+# _process_message end-to-end routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_message_resolves_pending_future():
+    """When a WS message arrives via the reader, the pending future is resolved."""
+    ws_client = _make_ws_client()
+    loop = asyncio.get_event_loop()
+
+    future = loop.create_future()
+    ws_client._pending_requests[1234] = future
+
+    raw_response = json.dumps({"id": 1234, "jsonrpc": "2.0", "result": {"order_id": "x", "status": "cancelled"}})
+    await ws_client._process_message(raw_response)
+
+    assert future.done()
+    assert future.result()["result"]["order_id"] == "x"
+    assert 1234 not in ws_client._pending_requests
+
+
+@pytest.mark.asyncio
+async def test_process_message_does_not_route_subscription_ack_to_pending():
+    """Subscription acks are not consumed by the pending-requests map."""
+    ws_client = _make_ws_client()
+    loop = asyncio.get_event_loop()
+
+    # Register a pending request with id=5
+    future = loop.create_future()
+    ws_client._pending_requests[5] = future
+
+    # Arrive a subscription ack with a *different* id
+    raw_ack = json.dumps({"id": 99, "jsonrpc": "2.0", "result": {"channel": "orders.BTC-USD-PERP"}})
+    await ws_client._process_message(raw_ack)
+
+    # Subscription was recorded
+    assert ws_client.subscribed_channels.get("orders.BTC-USD-PERP") is True
+    # Pending request for id=5 is untouched
+    assert not future.done()
+    assert 5 in ws_client._pending_requests
+
+    # Clean up
+    future.cancel()


### PR DESCRIPTION
## Summary

Implements WebSocket order management on `ParadexWebsocketClient` to mirror the server-side API added in tradeparadigm/mono#33320. Users switch from REST to WebSocket transport by using `ws_client.*` instead of `api_client.*` — method names are intentionally identical.

- `submit_order` / `submit_orders_batch` → `order.create` / `order.create_batch`
- `modify_order` → `order.modify`
- `cancel_order` / `cancel_order_by_client_id` → `order.cancel`
- `cancel_all_orders` → `order.cancel_all`
- `cancel_orders_batch` → `order.cancel_batch`
- `cancel_on_disconnect(enabled)` → `order.cancel_on_disconnect` (OFF by default, session-scoped, resets on reconnect)

On disconnect, all in-flight requests immediately raise `ConnectionError` rather than waiting for their timeout. Re-enable CoD after each reconnect if needed.