### PR TITLE
Add EVM wallet authentication and subkey/token management

### DIFF
--- a/examples/evm_onboard_and_trade.py
+++ b/examples/evm_onboard_and_trade.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """
-Example: EVM wallet onboarding → subkey creation → order submission.
+Example: EVM wallet onboarding → subkey creation → order submission + WS subscriptions.
 
 Full flow:
   1. Generate (or load) an EVM private key
   2. Create ParadexEvm — automatically onboards via SIWE and obtains a JWT
-  3. Generate a fresh Starknet L2 key pair for the subkey
-  4. Register the L2 public key as an active subkey on the account
-  5. Authenticate as that subkey with ParadexSubkey
-  6. Submit and cancel a limit order via the subkey
+  3. Call create_trading_subkey() — generates a fresh Starknet subkey, registers it,
+     and returns a ready-to-trade ParadexSubkey client
+  4. Poll account balance until testnet faucet funds arrive
+  5. Submit and cancel a perp limit order (BTC-USD-PERP) via the subkey
+  6. Submit and cancel a spot limit order (DIME-USD) via the subkey — same signing flow
+  7. Subscribe to public (BBO) and private (ORDERS) WebSocket channels via the subkey
 
 Usage:
     # Generate a fresh EVM key each run (demo):
@@ -19,20 +21,57 @@ Usage:
     python examples/evm_onboard_and_trade.py
 """
 
+import asyncio
 import logging
 import os
-import secrets
+import time
 from decimal import Decimal
+from pathlib import Path
 
 from eth_account import Account
-from starknet_py.net.signer.stark_curve_signer import KeyPair
 
-from paradex_py import ParadexEvm, ParadexSubkey
+from paradex_py import ParadexEvm
+from paradex_py.api.ws_client import ParadexWebsocketChannel
 from paradex_py.common.order import Order, OrderSide, OrderType
 from paradex_py.environment import TESTNET
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dotenv loader — reads KEY=VALUE pairs into os.environ (no extra deps)
+# ---------------------------------------------------------------------------
+
+_DOTENV = Path(__file__).parent.parent / ".env.testlocal"
+
+
+def _load_dotenv(path: Path = _DOTENV) -> None:
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, value = line.partition("=")
+                os.environ.setdefault(key.strip(), value.strip())
+        logger.info(f"Loaded env from {path}")
+    except FileNotFoundError:
+        pass
+
+
+def _save_dotenv(updates: dict[str, str], path: Path = _DOTENV) -> None:
+    """Upsert key=value pairs in the dotenv file."""
+    lines = path.read_text().splitlines() if path.exists() else []
+    existing = {line.split("=", 1)[0].strip() for line in lines if "=" in line and not line.startswith("#")}
+    for key, value in updates.items():
+        entry = f"{key}={value}"
+        if key in existing:
+            lines = [entry if line.startswith(f"{key}=") else line for line in lines]
+        else:
+            lines.append(entry)
+    path.write_text("\n".join(lines) + "\n")
+    logger.info(f"Saved {list(updates)} to {path}")
+
+
+_load_dotenv()
 
 # ---------------------------------------------------------------------------
 # Step 1: EVM key
@@ -54,56 +93,60 @@ evm_paradex = ParadexEvm(
     evm_private_key=evm_private_key,
 )
 
-evm_starknet_address = hex(evm_paradex.account.l2_address)
-logger.info(f"Derived Starknet address: {evm_starknet_address}")
+logger.info(f"Derived Starknet address: {hex(evm_paradex.account.l2_address)}")
+logger.info(f"Auth level: {evm_paradex.auth_level}")  # FULL
 
-# ---------------------------------------------------------------------------
-# Step 3: Generate a fresh Starknet L2 key pair for the subkey
-# ---------------------------------------------------------------------------
-
-# Starknet keys are 252-bit field elements; use secrets for a random one
-l2_private_key_int = secrets.randbelow(2**251)
-key_pair = KeyPair.from_private_key(l2_private_key_int)
-l2_public_key_hex = hex(key_pair.public_key)
-l2_private_key_hex = hex(l2_private_key_int)
-logger.info(f"Generated subkey public key: {l2_public_key_hex}")
-
-# ---------------------------------------------------------------------------
-# Step 4: Register the subkey on the EVM account
-#   - Uses the JWT obtained in step 2
-#   - state="active" makes it immediately usable (no activation step needed)
-# ---------------------------------------------------------------------------
-
-evm_paradex.api_client.create_subkey(
+# Validate the account was onboarded with an EVM (eip191) key
+onboarding_info = evm_paradex.api_client.fetch_onboarding(
     {
-        "name": "evm-example-subkey",
-        "public_key": l2_public_key_hex,
-        "state": "active",
+        "account_signer_type": "eip191",
+        "eth_address": evm_paradex.account.evm_address,
     }
 )
-
-# Verify the subkey appears in the list
-subkeys = evm_paradex.api_client.fetch_subkeys()
-logger.info(f"Subkeys: {subkeys}")
+logger.info(f"Onboarding info: {onboarding_info}")
 
 # ---------------------------------------------------------------------------
-# Step 5: Authenticate as the subkey
-#   - l2_address is the *parent* account's Starknet address (EVM-derived)
-#   - ParadexSubkey calls /auth using the subkey's L2 key
+# Step 3: Create a trading subkey
+#   - Generates a fresh Starknet key pair
+#   - Registers it as an active subkey on the EVM account
+#   - Returns a ParadexSubkey client ready for order signing
 # ---------------------------------------------------------------------------
 
-subkey_paradex = ParadexSubkey(
-    env=TESTNET,
-    l2_private_key=l2_private_key_hex,
-    l2_address=evm_starknet_address,
-)
+# Reuse persisted subkey if available; create a new one otherwise
+_l2_key = os.getenv("SUBKEY_PRIVATE_KEY")
+_l2_addr = hex(evm_paradex.account.l2_address)
+if _l2_key:
+    from paradex_py import ParadexSubkey
+
+    subkey_paradex = ParadexSubkey(env=TESTNET, l2_private_key=_l2_key, l2_address=_l2_addr)
+    logger.info("Reusing persisted subkey")
+else:
+    subkey_paradex = evm_paradex.create_trading_subkey(name="evm-example-subkey")
+    # Persist so the same subkey is reused on next run
+    _save_dotenv({"SUBKEY_PRIVATE_KEY": hex(subkey_paradex.account.l2_private_key)})
 logger.info(f"Subkey auth level: {subkey_paradex.auth_level}")  # TRADING
 
 account_summary = subkey_paradex.api_client.fetch_account_summary()
 logger.info(f"Account summary: {account_summary}")
 
 # ---------------------------------------------------------------------------
-# Step 6: Submit and cancel a limit order via the subkey
+# Step 4: Wait for testnet faucet funds before trading
+# ---------------------------------------------------------------------------
+
+logger.info("Waiting for testnet funds...")
+while True:
+    balances = subkey_paradex.api_client.fetch_balances()
+    results = balances.get("results", [])
+    usdc = next((b for b in results if b.get("token") == "USDC"), None)
+    usdc_size = Decimal(usdc["size"]) if usdc else Decimal(0)
+    if usdc_size > 0:
+        logger.info(f"Funds available: {usdc_size} USDC")
+        break
+    logger.info("No funds yet, retrying in 5s...")
+    time.sleep(5)
+
+# ---------------------------------------------------------------------------
+# Step 5: Submit and cancel a limit order via the subkey
 # ---------------------------------------------------------------------------
 
 buy_order = Order(
@@ -121,9 +164,80 @@ order_id = response.get("id")
 logger.info(f"Order submitted: {response}")
 
 if order_id:
-    subkey_paradex.api_client.cancel_order(order_id=order_id)
-    logger.info(f"Order {order_id} cancelled")
+    try:
+        subkey_paradex.api_client.cancel_order(order_id=order_id)
+        logger.info(f"Order {order_id} cancelled")
+    except ValueError:
+        logger.info(f"Order {order_id} already closed (POST_ONLY rejected below market)")
 
-# Optional: revoke the subkey when done
-# evm_paradex.api_client.revoke_subkey(l2_public_key_hex)
-# logger.info("Subkey revoked")
+# ---------------------------------------------------------------------------
+# Step 6: Spot trade USDC → DIME via the subkey
+#   - Spot orders use the same Order class and signing as perp orders
+#   - Market format: BASE-QUOTE (e.g. DIME-USD), no "-PERP" suffix
+#   - BUY side acquires DIME, spending USDC at the quoted price
+# ---------------------------------------------------------------------------
+
+spot_buy = Order(
+    market="DIME-USD",
+    order_type=OrderType.Limit,
+    order_side=OrderSide.Buy,
+    size=Decimal("100"),  # 100 DIME
+    limit_price=Decimal("0.05"),  # at mark price — GTC, rests in book
+    instruction="GTC",
+    reduce_only=False,
+)
+
+spot_response = subkey_paradex.api_client.submit_order(order=spot_buy)
+spot_order_id = spot_response.get("id")
+logger.info(f"Spot order submitted: {spot_response}")
+
+# Confirm the order rests in the book before cancelling
+open_orders = subkey_paradex.api_client.fetch_orders({"market": "DIME-USD", "status": "NEW"})
+logger.info(f"Open DIME-USD orders: {open_orders}")
+
+if spot_order_id:
+    try:
+        subkey_paradex.api_client.cancel_order(order_id=spot_order_id)
+        logger.info(f"Spot order {spot_order_id} cancelled")
+    except ValueError:
+        logger.info(f"Spot order {spot_order_id} already closed (filled or rejected)")
+
+# ---------------------------------------------------------------------------
+# Step 7: WebSocket subscriptions via the subkey
+#   - Public channel: BBO for BTC-USD-PERP
+#   - Private channel: ORDERS (authenticated via subkey JWT)
+# ---------------------------------------------------------------------------
+
+
+async def ws_demo() -> None:
+    ws = subkey_paradex.ws_client
+
+    async def on_bbo(channel: ParadexWebsocketChannel, msg: dict) -> None:
+        logger.info(f"WS BBO: {msg}")
+
+    async def on_orders(channel: ParadexWebsocketChannel, msg: dict) -> None:
+        logger.info(f"WS ORDERS: {msg}")
+
+    async def on_fills(channel: ParadexWebsocketChannel, msg: dict) -> None:
+        logger.info(f"WS FILLS: {msg}")
+
+    connected = await ws.connect()
+    logger.info(f"WS connected: {connected}")
+
+    await ws.subscribe(ParadexWebsocketChannel.BBO, callback=on_bbo, params={"market": "BTC-USD-PERP"})
+    logger.info("Subscribed to BBO")
+
+    await ws.subscribe(ParadexWebsocketChannel.ORDERS, callback=on_orders, params={"market": "ALL"})
+    logger.info("Subscribed to ORDERS")
+
+    await ws.subscribe(ParadexWebsocketChannel.FILLS, callback=on_fills, params={"market": "ALL"})
+    logger.info("Subscribed to FILLS")
+
+    logger.info("Listening for 5 seconds...")
+    await asyncio.sleep(5)
+
+    await ws.close()
+    logger.info("WS closed")
+
+
+asyncio.run(ws_demo())

--- a/examples/evm_onboard_and_trade.py
+++ b/examples/evm_onboard_and_trade.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Example: EVM wallet onboarding → subkey creation → order submission.
+
+Full flow:
+  1. Generate (or load) an EVM private key
+  2. Create ParadexEvm — automatically onboards via SIWE and obtains a JWT
+  3. Generate a fresh Starknet L2 key pair for the subkey
+  4. Register the L2 public key as an active subkey on the account
+  5. Authenticate as that subkey with ParadexSubkey
+  6. Submit and cancel a limit order via the subkey
+
+Usage:
+    # Generate a fresh EVM key each run (demo):
+    python examples/evm_onboard_and_trade.py
+
+    # Use an existing EVM key:
+    export EVM_PRIVATE_KEY="0x<your-key>"
+    python examples/evm_onboard_and_trade.py
+"""
+
+import logging
+import os
+import secrets
+from decimal import Decimal
+
+from eth_account import Account
+from starknet_py.net.signer.stark_curve_signer import KeyPair
+
+from paradex_py import ParadexEvm, ParadexSubkey
+from paradex_py.common.order import Order, OrderSide, OrderType
+from paradex_py.environment import TESTNET
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Step 1: EVM key
+# ---------------------------------------------------------------------------
+
+evm_private_key = os.getenv("EVM_PRIVATE_KEY") or Account.create().key.hex()
+evm_address = Account.from_key(evm_private_key).address
+logger.info(f"EVM address: {evm_address}")
+
+# ---------------------------------------------------------------------------
+# Step 2: Onboard with EVM key (SIWE)
+#   - Calls POST /v2/onboarding (first run) then POST /v2/auth
+#   - Stores the JWT automatically in api_client
+# ---------------------------------------------------------------------------
+
+evm_paradex = ParadexEvm(
+    env=TESTNET,
+    evm_address=evm_address,
+    evm_private_key=evm_private_key,
+)
+
+evm_starknet_address = hex(evm_paradex.account.l2_address)
+logger.info(f"Derived Starknet address: {evm_starknet_address}")
+
+# ---------------------------------------------------------------------------
+# Step 3: Generate a fresh Starknet L2 key pair for the subkey
+# ---------------------------------------------------------------------------
+
+# Starknet keys are 252-bit field elements; use secrets for a random one
+l2_private_key_int = secrets.randbelow(2**251)
+key_pair = KeyPair.from_private_key(l2_private_key_int)
+l2_public_key_hex = hex(key_pair.public_key)
+l2_private_key_hex = hex(l2_private_key_int)
+logger.info(f"Generated subkey public key: {l2_public_key_hex}")
+
+# ---------------------------------------------------------------------------
+# Step 4: Register the subkey on the EVM account
+#   - Uses the JWT obtained in step 2
+#   - state="active" makes it immediately usable (no activation step needed)
+# ---------------------------------------------------------------------------
+
+evm_paradex.api_client.create_subkey(
+    {
+        "name": "evm-example-subkey",
+        "public_key": l2_public_key_hex,
+        "state": "active",
+    }
+)
+
+# Verify the subkey appears in the list
+subkeys = evm_paradex.api_client.fetch_subkeys()
+logger.info(f"Subkeys: {subkeys}")
+
+# ---------------------------------------------------------------------------
+# Step 5: Authenticate as the subkey
+#   - l2_address is the *parent* account's Starknet address (EVM-derived)
+#   - ParadexSubkey calls /auth using the subkey's L2 key
+# ---------------------------------------------------------------------------
+
+subkey_paradex = ParadexSubkey(
+    env=TESTNET,
+    l2_private_key=l2_private_key_hex,
+    l2_address=evm_starknet_address,
+)
+logger.info(f"Subkey auth level: {subkey_paradex.auth_level}")  # TRADING
+
+account_summary = subkey_paradex.api_client.fetch_account_summary()
+logger.info(f"Account summary: {account_summary}")
+
+# ---------------------------------------------------------------------------
+# Step 6: Submit and cancel a limit order via the subkey
+# ---------------------------------------------------------------------------
+
+buy_order = Order(
+    market="BTC-USD-PERP",
+    order_type=OrderType.Limit,
+    order_side=OrderSide.Buy,
+    size=Decimal("0.001"),
+    limit_price=Decimal("10000"),  # far below market — won't fill
+    instruction="POST_ONLY",
+    reduce_only=False,
+)
+
+response = subkey_paradex.api_client.submit_order(order=buy_order)
+order_id = response.get("id")
+logger.info(f"Order submitted: {response}")
+
+if order_id:
+    subkey_paradex.api_client.cancel_order(order_id=order_id)
+    logger.info(f"Order {order_id} cancelled")
+
+# Optional: revoke the subkey when done
+# evm_paradex.api_client.revoke_subkey(l2_public_key_hex)
+# logger.info("Subkey revoked")

--- a/paradex_py/__init__.py
+++ b/paradex_py/__init__.py
@@ -2,24 +2,27 @@
 
 Choose the right client class for your use-case:
 
-+------------------+------------------+---------+-----------+---------+------------------+
-| Class            | Credentials      | Trade   | Withdraw  | Auth    | Typical use-case |
-+==================+==================+=========+===========+=========+==================+
-| Paradex          | L1 private key   | yes     | yes       | FULL    | Full account via |
-|                  | (or Ledger)      |         |           |         | L1 key           |
-+------------------+------------------+---------+-----------+---------+------------------+
-| ParadexL2        | L2 private key   | yes     | yes       | FULL    | Full account via |
-|                  | + L2 address     |         |           |         | L2 key directly  |
-+------------------+------------------+---------+-----------+---------+------------------+
-| ParadexSubkey    | L2 subkey        | yes     | no        | TRADING | Registered       |
-|                  | + main L2 addr   |         |           |         | trade-scoped key |
-+------------------+------------------+---------+-----------+---------+------------------+
-| ParadexEvm       | EVM private key  | no      | no        | AUTH    | EVM wallet;      |
-|                  |                  |         |           |         | manage subkeys   |
-+------------------+------------------+---------+-----------+---------+------------------+
-| ParadexApiKey    | Pre-generated    | no      | no        | AUTH    | Read-only /      |
-|                  | API token        |         |           |         | server-side apps |
-+------------------+------------------+---------+-----------+---------+------------------+
++------------------+------------------+---------+-----------+---------+--------------------------------+
+| Class            | Credentials      | Trade   | Withdraw  | Auth    | Typical use-case               |
++==================+==================+=========+===========+=========+================================+
+| Paradex          | L1 private key   | yes     | yes       | FULL    | Full account via L1 key        |
+|                  | (or Ledger)      |         |           |         |                                |
++------------------+------------------+---------+-----------+---------+--------------------------------+
+| ParadexL2        | L2 private key   | yes     | yes       | FULL    | Full account via L2 key        |
+|                  | + L2 address     |         |           |         |                                |
++------------------+------------------+---------+-----------+---------+--------------------------------+
+| ParadexEvm       | EVM private key  | no [1]  | yes       | FULL    | EVM wallet; full L2 account    |
+|                  |                  |         |           |         | (contract keyed to EVM pubkey) |
++------------------+------------------+---------+-----------+---------+--------------------------------+
+| ParadexSubkey    | L2 subkey        | yes     | no        | TRADING | Registered trade-scoped key    |
+|                  | + main L2 addr   |         |           |         |                                |
++------------------+------------------+---------+-----------+---------+--------------------------------+
+| ParadexApiKey    | Pre-generated    | no      | no        | AUTH    | Read-only / server-side apps   |
+|                  | API token        |         |           |         |                                |
++------------------+------------------+---------+-----------+---------+--------------------------------+
+
+[1] Order signing requires a registered Starknet subkey.
+    Call ``evm.create_trading_subkey()`` to generate one and get a ready-to-trade client.
 """
 
 from .auth_level import AuthLevel

--- a/paradex_py/__init__.py
+++ b/paradex_py/__init__.py
@@ -2,27 +2,31 @@
 
 Choose the right client class for your use-case:
 
-+------------------+------------------+---------+-----------+--------+------------------+
-| Class            | Credentials      | Trade   | Withdraw  | Auth   | Typical use-case |
-+==================+==================+=========+===========+========+==================+
-| Paradex          | L1 private key   | yes     | yes       | FULL   | Full account via |
-|                  | (or Ledger)      |         |           |        | L1 key           |
-+------------------+------------------+---------+-----------+--------+------------------+
-| ParadexL2        | L2 private key   | yes     | yes       | FULL   | Full account via |
-|                  | + L2 address     |         |           |        | L2 key directly  |
-+------------------+------------------+---------+-----------+--------+------------------+
-| ParadexSubkey    | L2 subkey        | yes     | no        | TRADING| Registered       |
-|                  | + main L2 addr   |         |           |        | trade-scoped key |
-+------------------+------------------+---------+-----------+--------+------------------+
-| ParadexApiKey    | Pre-generated    | no      | no        | AUTH   | Read-only /      |
-|                  | API token        |         |           |        | server-side apps |
-+------------------+------------------+---------+-----------+--------+------------------+
++------------------+------------------+---------+-----------+---------+------------------+
+| Class            | Credentials      | Trade   | Withdraw  | Auth    | Typical use-case |
++==================+==================+=========+===========+=========+==================+
+| Paradex          | L1 private key   | yes     | yes       | FULL    | Full account via |
+|                  | (or Ledger)      |         |           |         | L1 key           |
++------------------+------------------+---------+-----------+---------+------------------+
+| ParadexL2        | L2 private key   | yes     | yes       | FULL    | Full account via |
+|                  | + L2 address     |         |           |         | L2 key directly  |
++------------------+------------------+---------+-----------+---------+------------------+
+| ParadexSubkey    | L2 subkey        | yes     | no        | TRADING | Registered       |
+|                  | + main L2 addr   |         |           |         | trade-scoped key |
++------------------+------------------+---------+-----------+---------+------------------+
+| ParadexEvm       | EVM private key  | no      | no        | AUTH    | EVM wallet;      |
+|                  |                  |         |           |         | manage subkeys   |
++------------------+------------------+---------+-----------+---------+------------------+
+| ParadexApiKey    | Pre-generated    | no      | no        | AUTH    | Read-only /      |
+|                  | API token        |         |           |         | server-side apps |
++------------------+------------------+---------+-----------+---------+------------------+
 """
 
 from .auth_level import AuthLevel
 from .environment import NIGHTLY, PROD, TESTNET, Environment
 from .paradex import Paradex
 from .paradex_api_key import ParadexApiKey
+from .paradex_evm import ParadexEvm
 from .paradex_l2 import ParadexL2
 from .paradex_subkey import ParadexSubkey
 
@@ -34,6 +38,7 @@ __all__ = [
     "TESTNET",
     "Paradex",
     "ParadexApiKey",
+    "ParadexEvm",
     "ParadexL2",
     "ParadexSubkey",
 ]

--- a/paradex_py/account/evm_account.py
+++ b/paradex_py/account/evm_account.py
@@ -1,0 +1,175 @@
+import base64
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from eth_keys import keys as eth_keys
+from starknet_py.common import int_from_hex
+from starknet_py.hash.address import compute_address
+
+from paradex_py.api.models import SystemConfig
+from paradex_py.environment import Environment
+from paradex_py.utils import raise_value_error
+
+_SIWE_DOMAIN: dict[str, str] = {
+    "prod": "app.paradex.trade",
+    "testnet": "app.testnet.paradex.trade",
+    "nightly": "app.nightly.paradex.trade",
+}
+
+_SIWE_AUTH_EXPIRY_SECONDS = 5 * 60  # 5 minutes, matching Paradex web app
+
+
+class EvmAccount:
+    """Paradex account authenticated via EVM key using SIWE (ERC-4361).
+
+    The Starknet address is deterministically derived from the EVM address using
+    Argent v0.5.0 direct deployment (no proxy). Trading requires a registered subkey.
+
+    Args:
+        config (SystemConfig): System configuration (must have paraclear_evm_account_hash).
+        env (Environment): Environment (used to select the SIWE domain).
+        evm_address (str): Ethereum address (checksummed or lowercase hex).
+        evm_private_key (str): Ethereum private key (hex string with 0x prefix).
+
+    Examples:
+        >>> from paradex_py.account.evm_account import EvmAccount
+        >>> account = EvmAccount(
+        ...     config=config,
+        ...     env="prod",
+        ...     evm_address="0x...",
+        ...     evm_private_key="0x...",
+        ... )
+        >>> hex(account.l2_address)
+        '0x...'
+    """
+
+    def __init__(
+        self,
+        config: SystemConfig,
+        env: Environment,
+        evm_address: str,
+        evm_private_key: str,
+    ):
+        if not config.paraclear_evm_account_hash:
+            raise_value_error("EvmAccount: paraclear_evm_account_hash not available in system config")
+        if not evm_address:
+            raise_value_error("EvmAccount: EVM address is required")
+        if not evm_private_key:
+            raise_value_error("EvmAccount: EVM private key is required")
+
+        self.config = config
+        self.env = env
+
+        # Normalise address to checksum format
+        self._eth_account = Account.from_key(evm_private_key)
+        self.l1_address = self._eth_account.address  # checksum address
+        self.evm_address = self.l1_address
+
+        # Uncompressed secp256k1 public key: "0x04" + 128-char hex (x || y)
+        _priv_key_obj = eth_keys.PrivateKey(bytes(self._eth_account.key))
+        self.evm_public_key_uncompressed = "0x04" + _priv_key_obj.public_key.to_bytes().hex()
+
+        # Derive Starknet address — Argent v0.5.0 direct (no proxy)
+        self.l2_address = self._compute_starknet_address()
+
+    # ------------------------------------------------------------------
+    # Starknet address derivation
+    # ------------------------------------------------------------------
+
+    def _compute_starknet_address(self) -> int:
+        """Derive the Starknet address from the EVM address.
+
+        Uses Argent v0.5.0 direct deployment with EIP-191 signer type:
+          calldata = [3 (Eip191 variant), eth_address, 1 (Option::None guardian)]
+          salt     = eth_address
+          deployer = 0
+        """
+        # paraclear_evm_account_hash is guaranteed non-None by __init__ guard
+        evm_class_hash: str = self.config.paraclear_evm_account_hash  # type: ignore[assignment]
+        eth_addr_int = int_from_hex(self.evm_address)
+        calldata = [3, eth_addr_int, 1]
+        return compute_address(
+            class_hash=int_from_hex(evm_class_hash),
+            constructor_calldata=calldata,
+            salt=eth_addr_int,
+            deployer_address=0,
+        )
+
+    # ------------------------------------------------------------------
+    # SIWE helpers
+    # ------------------------------------------------------------------
+
+    def _siwe_domain(self) -> str:
+        return _SIWE_DOMAIN.get(str(self.env), "app.paradex.trade")
+
+    def _build_siwe_onboarding(self) -> str:
+        """Build ERC-4361 SIWE onboarding message (no expirationTime)."""
+        domain = self._siwe_domain()
+        nonce = secrets.token_hex(16)
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return (
+            f"{domain} wants you to sign in with your Ethereum account:\n"
+            f"{self.evm_address}\n"
+            "\n"
+            "Paradex Onboarding\n"
+            "\n"
+            f"URI: https://{domain}\n"
+            "Version: 1\n"
+            f"Chain ID: {self.config.l1_chain_id}\n"
+            f"Nonce: {nonce}\n"
+            f"Issued At: {now}"
+        )
+
+    def _build_siwe_auth(self) -> str:
+        """Build ERC-4361 SIWE auth message (with expirationTime)."""
+        domain = self._siwe_domain()
+        nonce = secrets.token_hex(16)
+        now = datetime.now(timezone.utc)
+        expiry = now + timedelta(seconds=_SIWE_AUTH_EXPIRY_SECONDS)
+        now_str = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        expiry_str = expiry.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return (
+            f"{domain} wants you to sign in with your Ethereum account:\n"
+            f"{self.evm_address}\n"
+            "\n"
+            "Paradex Auth\n"
+            "\n"
+            f"URI: https://{domain}\n"
+            "Version: 1\n"
+            f"Chain ID: {self.config.l1_chain_id}\n"
+            f"Nonce: {nonce}\n"
+            f"Issued At: {now_str}\n"
+            f"Expiration Time: {expiry_str}"
+        )
+
+    def _sign_eip191(self, message: str) -> str:
+        """Sign a plaintext message with EIP-191 personal_sign."""
+        msg = encode_defunct(text=message)
+        signed = self._eth_account.sign_message(msg)
+        sig_hex = signed.signature.hex()
+        return sig_hex if sig_hex.startswith("0x") else "0x" + sig_hex
+
+    # ------------------------------------------------------------------
+    # Auth header builders (same interface as ParadexAccount)
+    # ------------------------------------------------------------------
+
+    def onboarding_headers(self) -> dict:
+        siwe = self._build_siwe_onboarding()
+        return {
+            "PARADEX-STARKNET-ACCOUNT": hex(self.l2_address),
+            "PARADEX-EVM-SIGNATURE": self._sign_eip191(siwe),
+            "PARADEX-SIWE-MESSAGE": base64.b64encode(siwe.encode()).decode(),
+        }
+
+    def auth_headers(self) -> dict:
+        siwe = self._build_siwe_auth()
+        return {
+            "PARADEX-STARKNET-ACCOUNT": hex(self.l2_address),
+            "PARADEX-EVM-SIGNATURE": self._sign_eip191(siwe),
+            "PARADEX-SIWE-MESSAGE": base64.b64encode(siwe.encode()).decode(),
+        }
+
+    def set_jwt_token(self, jwt_token: str) -> None:
+        self.jwt_token = jwt_token

--- a/paradex_py/api/api_client.py
+++ b/paradex_py/api/api_client.py
@@ -4,7 +4,7 @@ import logging
 import re
 import time
 from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 
@@ -16,6 +16,9 @@ from paradex_py.api.protocols import AuthProvider, RetryStrategy, Signer
 from paradex_py.common.order import Order
 from paradex_py.environment import Environment
 from paradex_py.utils import raise_value_error
+
+if TYPE_CHECKING:
+    from paradex_py.account.evm_account import EvmAccount
 
 _REFRESH_BUFFER_SECONDS = 30  # refresh 30s before JWT expiry to avoid race conditions
 _OPAQUE_TOKEN_LIFETIME_SECONDS = 4 * 60  # assumed lifetime for tokens without an exp claim
@@ -98,8 +101,10 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         # Use custom base URL if provided, otherwise use default
         if api_base_url is not None:
             self.api_url = api_base_url
+            self._v2_api_url = api_base_url.replace("/v1", "/v2")
         else:
             self.api_url = f"https://api.{self.env}.paradex.trade/v1"
+            self._v2_api_url = f"https://api.{self.env}.paradex.trade/v2"
 
         # Auth configuration
         self.auto_auth = auto_auth
@@ -109,10 +114,14 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         self._token_exp: float | None = None
         self.on_token_expired: Callable[[], str | None] | None = on_token_expired
         self.account: ParadexAccount | None = None
+        self._evm_account: "EvmAccount | None" = None
         self.auth_timestamp = 0
 
         # Signing configuration
         self.signer = signer
+
+        # EVM account flag (set by init_account_evm)
+        self._is_evm_account = False
 
     def init_account(self, account: ParadexAccount):
         self.account = account
@@ -144,6 +153,40 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         self.auth_timestamp = int(time.time())
         self._token_exp = _jwt_exp(data.jwt_token)
         self.account.set_jwt_token(data.jwt_token)
+        self.client.headers.update({"Authorization": f"Bearer {data.jwt_token}"})
+
+    def init_account_evm(self, account: "EvmAccount"):
+        """Initialize an EVM account and run the v2 onboarding/auth flow."""
+        self._evm_account = account
+        self._is_evm_account = True
+        if self.auto_auth:
+            try:
+                self.auth_evm(params=self.auth_params)
+            except ValueError as e:
+                if "NOT_ONBOARDED" in str(e):
+                    self.onboarding_evm()
+                    self.auth_evm(params=self.auth_params)
+                else:
+                    raise
+
+    def onboarding_evm(self):
+        """Onboard an EVM account via POST /v2/onboarding (SIWE)."""
+        if self._evm_account is None:
+            raise ValueError("EVM account not initialized")
+        headers = self._evm_account.onboarding_headers()
+        payload = {"public_key": self._evm_account.evm_public_key_uncompressed}
+        self.post(api_url=self._v2_api_url, path="onboarding", headers=headers, payload=payload)
+
+    def auth_evm(self, params: dict | None = None):
+        """Obtain a JWT for an EVM account via POST /v2/auth (SIWE)."""
+        if self._evm_account is None:
+            raise ValueError("EVM account not initialized")
+        headers = self._evm_account.auth_headers()
+        res = self.post(api_url=self._v2_api_url, path="auth", headers=headers, params=params)
+        data = AuthSchema().load(res, unknown="exclude", partial=True)
+        self.auth_timestamp = int(time.time())
+        self._token_exp = _jwt_exp(data.jwt_token)
+        self._evm_account.set_jwt_token(data.jwt_token)
         self.client.headers.update({"Authorization": f"Bearer {data.jwt_token}"})
 
     def set_token(self, jwt: str) -> None:
@@ -205,7 +248,7 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
                 return
 
         # Fall back to standard account-based auth
-        if self.account is None:
+        if self.account is None and self._evm_account is None:
             if not self.auto_auth:
                 return  # Skip auth if disabled and no account
             raise_value_error(f"{self.classname}: Account not found")
@@ -213,7 +256,10 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         # Refresh JWT if expired
         if self._is_token_expired():
             if self.auto_auth:
-                self.auth(params=self.auth_params)
+                if self._is_evm_account:
+                    self.auth_evm(params=self.auth_params)
+                else:
+                    self.auth(params=self.auth_params)
             else:
                 self.logger.warning(f"{self.classname}: JWT expired but auto_auth disabled")
 
@@ -500,6 +546,113 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         Private endpoint requires authorization.
         """
         return self._get_authorized(path="account/info")
+
+    # SUBKEY MANAGEMENT
+
+    def fetch_subkeys(self, params: dict | None = None) -> dict:
+        """List all subkeys for this account.
+        Private endpoint requires authorization.
+
+        Args:
+            params:
+                `include_revoked`: Include revoked subkeys in results\n
+
+        Returns:
+            results (list): List of Subkeys
+        """
+        return self._get_authorized(path="account/keys/subkeys", params=params)
+
+    def create_subkey(self, payload: dict) -> None:
+        """Register a new subkey for this account.
+        Private endpoint requires authorization.
+
+        Args:
+            payload: CreateSubkey fields — name, public_key, state ('active' or 'pending'),
+                     encrypted_key and eph_public_key (required when state='pending').
+
+        Returns:
+            None (server responds with 204 No Content on success)
+        """
+        self._post_authorized(path="account/keys/subkeys", payload=payload)
+
+    def activate_subkey(self, payload: dict) -> dict:
+        """Activate a pending subkey via Starknet signature.
+        Private endpoint requires authorization.
+
+        The signature must be [r, s] over pedersen(timestamp, eph_public_key),
+        produced by the main account's Starknet key.
+
+        Args:
+            payload: ActivateSubkey fields — account_id, public_key, timestamp, signature, name.
+
+        Returns:
+            ActivateSubkeyResponse dict (may include encrypted_key)
+        """
+        return self._post_authorized(path="account/keys/subkeys/activate", payload=payload)
+
+    def fetch_subkey(self, public_key: str) -> dict:
+        """Fetch a specific subkey by its public key.
+        Private endpoint requires authorization.
+
+        Args:
+            public_key: Public key of the subkey to fetch.
+        """
+        return self._get_authorized(path=f"account/keys/subkeys/{public_key}")
+
+    def update_subkey(self, public_key: str, payload: dict) -> dict:
+        """Update a subkey (e.g. rename it).
+        Private endpoint requires authorization.
+
+        Args:
+            public_key: Public key of the subkey to update.
+            payload: UpdateSubkey fields — name.
+        """
+        return self._put_authorized(path=f"account/keys/subkeys/{public_key}", payload=payload)
+
+    def revoke_subkey(self, public_key: str) -> None:
+        """Revoke a subkey permanently.
+        Private endpoint requires authorization.
+
+        Args:
+            public_key: Public key of the subkey to revoke.
+        """
+        self._delete_authorized(path=f"account/keys/subkeys/{public_key}")
+
+    # TOKEN MANAGEMENT
+
+    def fetch_tokens(self, params: dict | None = None) -> dict:
+        """List authentication tokens for this account.
+        Private endpoint requires authorization.
+
+        Args:
+            params:
+                `kind`: Filter by token kind ('jwt' or 'api_key')\n
+
+        Returns:
+            results (list): List of ApiToken entries
+        """
+        return self._get_authorized(path="account/tokens", params=params)
+
+    def create_token(self, payload: dict) -> dict:
+        """Create a new authentication token (JWT or API key).
+        Private endpoint requires authorization.
+
+        Args:
+            payload: CreateToken fields — name, token_type, expiry_duration (seconds).
+
+        Returns:
+            ApiToken response dict
+        """
+        return self._post_authorized(path="account/tokens", payload=payload)
+
+    def revoke_token(self, lookup_id: str) -> None:
+        """Revoke an authentication token by its lookup ID.
+        Private endpoint requires authorization.
+
+        Args:
+            lookup_id: Lookup ID of the token to revoke.
+        """
+        self._delete_authorized(path=f"account/tokens/{lookup_id}")
 
     def submit_order(self, order: Order, signer: Signer | None = None) -> dict:
         """Send order to Paradex.

--- a/paradex_py/api/api_client.py
+++ b/paradex_py/api/api_client.py
@@ -135,6 +135,30 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
                 else:
                     raise
 
+    def fetch_onboarding(self, params: dict | None = None) -> dict:
+        """Check whether an account has been onboarded.
+
+        Public endpoint — no authentication required.
+
+        Args:
+            params: Query parameters. Exactly one of two forms:
+
+                Starknet account (``account_signer_type="starknet"``)::
+
+                    {"account_signer_type": "starknet", "public_key": "0x<l2_pubkey>"}
+
+                EVM account (``account_signer_type="eip191"``)::
+
+                    {"account_signer_type": "eip191", "eth_address": "0x<evm_address>"}
+
+                Note: ``public_key`` is ignored by the server for EIP-191 accounts.
+
+        Returns:
+            dict with ``address``, ``exists`` (bool), ``account_signer_type``, and
+            ``derivation_info``.
+        """
+        return self.get(api_url=self.api_url, path="onboarding", params=params)
+
     def onboarding(self):
         if self.account is None:
             raise ValueError("Account not initialized")

--- a/paradex_py/api/generated/__init__.py
+++ b/paradex_py/api/generated/__init__.py
@@ -1,6 +1,6 @@
-# Generated from Paradex API spec version 1.114.2
+# Generated from Paradex API spec version 1.116.1
 
-"""Generated API models from Paradex OpenAPI spec v1.114.2."""
+"""Generated API models from Paradex OpenAPI spec v1.116.1."""
 
 # ruff: noqa: F403, A003
 # Import all generated models

--- a/paradex_py/api/generated/messagesv1.py
+++ b/paradex_py/api/generated/messagesv1.py
@@ -1,0 +1,15 @@
+# Generated from Paradex API spec version 1.116.1
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NftPrice(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+    )
+    currency: str | None = None
+    decimals: int | None = None
+    value: str | None = None

--- a/paradex_py/api/generated/requests.py
+++ b/paradex_py/api/generated/requests.py
@@ -1,4 +1,4 @@
-# Generated from Paradex API spec version 1.114.2
+# Generated from Paradex API spec version 1.116.1
 
 from __future__ import annotations
 

--- a/paradex_py/api/generated/responses.py
+++ b/paradex_py/api/generated/responses.py
@@ -1,4 +1,4 @@
-# Generated from Paradex API spec version 1.114.2
+# Generated from Paradex API spec version 1.116.1
 
 from __future__ import annotations
 
@@ -7,15 +7,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
-class NftPrice(BaseModel):
-    model_config = ConfigDict(
-        extra="allow",
-        populate_by_name=True,
-    )
-    currency: str | None = None
-    decimals: int | None = None
-    value: str | None = None
+from . import messagesv1
 
 
 class APIResults(BaseModel):
@@ -817,7 +809,7 @@ class Nft(BaseModel):
     id: str | None = None
     image_url: str | None = None
     name: str | None = None
-    price: NftPrice | None = None
+    price: messagesv1.NftPrice | None = None
 
 
 class NotificationPreferencesResp(BaseModel):
@@ -830,6 +822,15 @@ class NotificationPreferencesResp(BaseModel):
     fills: Annotated[bool | None, Field(examples=[True])] = None
     orders: Annotated[bool | None, Field(examples=[True])] = None
     transfers: Annotated[bool | None, Field(examples=[True])] = None
+
+
+class OnboardingDerivationInfo(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+    )
+    class_hash: str | None = None
+    proxy_class_hash: str | None = None
 
 
 class OptionMarginParams(BaseModel):
@@ -1897,6 +1898,19 @@ class GetAccountsInfoResponse(BaseModel):
         populate_by_name=True,
     )
     results: list[AccountInfoResponse] | None = None
+
+
+class GetOnboardingResp(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+    )
+    account_signer_type: Annotated[str | None, Field(description='Signer variant: "starknet" or "eip191"')] = None
+    address: Annotated[str | None, Field(description="Paradex Starknet address")] = None
+    derivation_info: Annotated[
+        OnboardingDerivationInfo | None, Field(description="Class hash(es) used for address derivation")
+    ] = None
+    exists: Annotated[bool | None, Field(description="Whether the account is already onboarded")] = None
 
 
 class GetSubAccountsResponse(BaseModel):

--- a/paradex_py/api/models.py
+++ b/paradex_py/api/models.py
@@ -38,6 +38,7 @@ class SystemConfig:
     l1_operator_address: str
     l1_chain_id: str
     liquidation_fee: str
+    paraclear_evm_account_hash: str | None = None
 
 
 @dataclass

--- a/paradex_py/auth_level.py
+++ b/paradex_py/auth_level.py
@@ -32,6 +32,7 @@ class AuthLevel(IntEnum):
     Typical for ``ParadexSubkey``."""
 
     FULL = 3
-    """Full L2 account key — unrestricted access: order signing + all direct on-chain
-    operations (deposit, withdraw, transfer).
-    Typical for ``ParadexL2`` (main account key) and ``Paradex`` (L1-derived key)."""
+    """Full L2 account — all on-chain operations supported (deposit, withdraw, transfer).
+    Order signing is also available when the account holds a direct Starknet signing key
+    (``Paradex``, ``ParadexL2``).  EVM accounts (``ParadexEvm``) are FULL but require a
+    registered subkey for order signing."""

--- a/paradex_py/paradex_evm.py
+++ b/paradex_py/paradex_evm.py
@@ -1,4 +1,8 @@
 import logging
+import secrets
+from typing import TYPE_CHECKING
+
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 from paradex_py._client_base import _ClientBase
 from paradex_py.account.evm_account import EvmAccount
@@ -7,6 +11,9 @@ from paradex_py.api.ws_client import ParadexWebsocketClient
 from paradex_py.auth_level import AuthLevel
 from paradex_py.environment import Environment, _validate_env
 from paradex_py.utils import raise_value_error
+
+if TYPE_CHECKING:
+    from paradex_py.paradex_subkey import ParadexSubkey
 
 __all__ = ["ParadexEvm"]
 
@@ -93,8 +100,8 @@ class ParadexEvm(_ClientBase):
 
     @property
     def auth_level(self) -> AuthLevel:
-        """``AuthLevel.AUTHENTICATED`` — JWT present, no Starknet signing key."""
-        return AuthLevel.AUTHENTICATED
+        """``AuthLevel.FULL`` — full L2 account; deposits and withdrawals supported."""
+        return AuthLevel.FULL
 
     @property
     def is_authenticated(self) -> bool:
@@ -103,10 +110,47 @@ class ParadexEvm(_ClientBase):
 
     @property
     def can_trade(self) -> bool:
-        """Always ``False`` — no Starknet L2 signing key; use a registered subkey."""
+        """Always ``False`` — order signing requires a registered Starknet subkey.
+        Use :meth:`create_trading_subkey` to generate one."""
         return False
 
     @property
     def can_withdraw(self) -> bool:
-        """Always ``False`` — no Starknet L2 signing key."""
-        return False
+        """Always ``True`` — the L2 account is owned by the EVM key; on-chain
+        operations (deposit, withdraw, transfer) are supported."""
+        return True
+
+    def create_trading_subkey(self, name: str = "trading") -> "ParadexSubkey":
+        """Generate a fresh Starknet subkey, register it, and return a ready-to-trade client.
+
+        This is the recommended way to enable trading from an EVM-authenticated account.
+        The generated private key is ephemeral — save it if you need to reuse the subkey
+        across sessions.
+
+        Args:
+            name (str): Human-readable label for the subkey. Defaults to ``"trading"``.
+
+        Returns:
+            ParadexSubkey: Authenticated client signed with the new subkey.
+
+        Examples:
+            >>> evm = ParadexEvm(env=TESTNET, evm_address="0x...", evm_private_key="0x...")
+            >>> subkey = evm.create_trading_subkey()
+            >>> subkey.api_client.submit_order(order=buy_order)
+        """
+        from paradex_py.paradex_subkey import ParadexSubkey
+
+        l2_private_key_int = secrets.randbelow(2**251)
+        key_pair = KeyPair.from_private_key(l2_private_key_int)
+        self.api_client.create_subkey(
+            {
+                "name": name,
+                "public_key": hex(key_pair.public_key),
+                "state": "active",
+            }
+        )
+        return ParadexSubkey(
+            env=self.env,
+            l2_private_key=hex(l2_private_key_int),
+            l2_address=hex(self.account.l2_address),
+        )

--- a/paradex_py/paradex_evm.py
+++ b/paradex_py/paradex_evm.py
@@ -1,0 +1,112 @@
+import logging
+
+from paradex_py._client_base import _ClientBase
+from paradex_py.account.evm_account import EvmAccount
+from paradex_py.api.api_client import ParadexApiClient
+from paradex_py.api.ws_client import ParadexWebsocketClient
+from paradex_py.auth_level import AuthLevel
+from paradex_py.environment import Environment, _validate_env
+from paradex_py.utils import raise_value_error
+
+__all__ = ["ParadexEvm"]
+
+
+class ParadexEvm(_ClientBase):
+    """Paradex client authenticated via EVM (Ethereum) key using SIWE (ERC-4361).
+
+    The Starknet address is derived deterministically from the EVM address.
+    This client provides ``AuthLevel.AUTHENTICATED`` — it can call all
+    authenticated REST endpoints but cannot sign orders directly (no Starknet
+    signing key). For trading, register a subkey with :meth:`api_client.create_subkey`
+    and use :class:`~paradex_py.ParadexSubkey`.
+
+    Args:
+        env (Environment): Environment
+        evm_address (str): Ethereum address (checksummed or lowercase hex).
+        evm_private_key (str): Ethereum private key (hex string with 0x prefix).
+        logger (logging.Logger, optional): Logger. Defaults to None.
+        ws_timeout (int, optional): WebSocket read timeout in seconds. Defaults to None.
+        ws_enabled (bool, optional): Whether to create a WebSocket client. Defaults to True.
+            Set to False for REST-only use cases.
+        ws_sbe_enabled (bool, optional): Enable SBE encoding on WebSocket. Defaults to False.
+
+    Examples:
+        >>> from paradex_py import ParadexEvm
+        >>> from paradex_py.environment import Environment
+        >>> paradex = ParadexEvm(
+        ...     env=Environment.TESTNET,
+        ...     evm_address="0x...",
+        ...     evm_private_key="0x...",
+        ... )
+        >>> paradex.api_client.fetch_balances()
+        >>> # List and create subkeys
+        >>> paradex.api_client.fetch_subkeys()
+        >>> paradex.api_client.create_subkey({
+        ...     "name": "trading-bot",
+        ...     "public_key": "0x...",
+        ...     "state": "active",
+        ... })
+    """
+
+    def __init__(
+        self,
+        env: Environment,
+        evm_address: str,
+        evm_private_key: str,
+        logger: logging.Logger | None = None,
+        ws_timeout: int | None = None,
+        ws_enabled: bool = True,
+        ws_sbe_enabled: bool = False,
+    ):
+        _validate_env(env, "ParadexEvm")
+
+        if not evm_address:
+            raise_value_error(f"ParadexEvm: EVM address is required, got {evm_address!r}")
+        if not evm_private_key:
+            raise_value_error("ParadexEvm: EVM private key is required")
+
+        self.env = env
+        self.logger: logging.Logger = logger or logging.getLogger(__name__)
+
+        self.api_client = ParadexApiClient(env=env, logger=logger)
+        self.ws_client: ParadexWebsocketClient | None = (
+            ParadexWebsocketClient(
+                env=env,
+                logger=logger,
+                ws_timeout=ws_timeout,
+                api_client=self.api_client,
+                sbe_enabled=ws_sbe_enabled,
+            )
+            if ws_enabled
+            else None
+        )
+        self.config = self.api_client.fetch_system_config()
+
+        self.account = EvmAccount(
+            config=self.config,
+            env=env,
+            evm_address=evm_address,
+            evm_private_key=evm_private_key,
+        )
+
+        self.api_client.init_account_evm(self.account)
+
+    @property
+    def auth_level(self) -> AuthLevel:
+        """``AuthLevel.AUTHENTICATED`` — JWT present, no Starknet signing key."""
+        return AuthLevel.AUTHENTICATED
+
+    @property
+    def is_authenticated(self) -> bool:
+        """Always ``True`` — credentials were provided at construction."""
+        return True
+
+    @property
+    def can_trade(self) -> bool:
+        """Always ``False`` — no Starknet L2 signing key; use a registered subkey."""
+        return False
+
+    @property
+    def can_withdraw(self) -> bool:
+        """Always ``False`` — no Starknet L2 signing key."""
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "starknet-py>=0.28.0,<0.29.0",
     "marshmallow-dataclass>=8.6.1,<9.0.0",
     "eth-account>=0.13.6",
+    "eth-keys>=0.6.1",
     "starknet-crypto-py>=0.2.0,<0.3.0",
     "httpx>=0.27.0,<0.28.0",
     "websockets>=15.0,<16.0",

--- a/tests/test_auth_modes.py
+++ b/tests/test_auth_modes.py
@@ -1,4 +1,4 @@
-"""Tests for AuthLevel, ParadexL2, ParadexSubkey, ParadexApiKey, and on_token_expired."""
+"""Tests for AuthLevel, ParadexL2, ParadexSubkey, ParadexApiKey, ParadexEvm, and on_token_expired."""
 
 import base64
 import json
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from paradex_py import AuthLevel, ParadexApiKey, ParadexL2, ParadexSubkey
+from paradex_py import AuthLevel, ParadexApiKey, ParadexEvm, ParadexL2, ParadexSubkey
 from paradex_py.api.api_client import ParadexApiClient, _jwt_exp
 from paradex_py.environment import TESTNET
 
@@ -16,6 +16,8 @@ MOCK_SYSTEM_CONFIG = MagicMock()
 L2_KEY = "0x1234567890abcdef"
 L2_ADDR = "0xdeadbeef"
 API_KEY = "test-api-key-token"
+EVM_ADDR = "0x846359e7bffc0AA5cB98767D94a874ec90f3944e"
+EVM_KEY = "0x" + "a" * 64
 
 
 def _make_jwt(exp: float) -> str:
@@ -574,6 +576,137 @@ class TestClosePartialInit:
 
         MockWsClient.return_value.close.assert_not_called()
         mock_api.client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ParadexEvm — full L2 account via EVM key
+# ---------------------------------------------------------------------------
+
+
+class TestParadexEvm:
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_successful_init(self, MockApiClient, MockWsClient, MockEvmAccount):
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+
+        p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY)
+
+        MockApiClient.assert_called_once_with(env=TESTNET, logger=None)
+        mock_api.fetch_system_config.assert_called_once()
+        MockEvmAccount.assert_called_once_with(
+            config=MOCK_SYSTEM_CONFIG,
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+        )
+        mock_api.init_account_evm.assert_called_once_with(MockEvmAccount.return_value)
+        assert p.config is MOCK_SYSTEM_CONFIG
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_ws_timeout_forwarded(self, MockApiClient, MockWsClient, MockEvmAccount):
+        MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY, ws_timeout=42)
+        MockWsClient.assert_called_once_with(
+            env=TESTNET, logger=None, ws_timeout=42, api_client=MockApiClient.return_value, sbe_enabled=False
+        )
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_ws_enabled_false_skips_ws_client(self, MockApiClient, MockWsClient, MockEvmAccount):
+        MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY, ws_enabled=False)
+        MockWsClient.assert_not_called()
+        assert p.ws_client is None
+
+    def test_missing_env_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            ParadexEvm(env=None, evm_address=EVM_ADDR, evm_private_key=EVM_KEY)
+
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_missing_evm_address_raises(self, MockApiClient):
+        MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        with pytest.raises(ValueError):
+            ParadexEvm(env=TESTNET, evm_address="", evm_private_key=EVM_KEY)
+
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_missing_evm_private_key_raises(self, MockApiClient):
+        MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        with pytest.raises(ValueError):
+            ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key="")
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_capabilities(self, MockApiClient, MockWsClient, MockEvmAccount):
+        """Full account: withdraw yes, trade no (needs subkey), auth FULL."""
+        MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY)
+        assert p.auth_level == AuthLevel.FULL
+        assert p.is_authenticated is True
+        assert p.can_trade is False
+        assert p.can_withdraw is True
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_create_trading_subkey_registers_and_returns_subkey(self, MockApiClient, MockWsClient, MockEvmAccount):
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        MockEvmAccount.return_value.l2_address = 0xDEADBEEF
+
+        p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY)
+
+        with (
+            patch("paradex_py.paradex_evm.KeyPair") as MockKeyPair,
+            patch("paradex_py.paradex_evm.secrets") as MockSecrets,
+            patch("paradex_py.paradex_subkey.ParadexSubkey") as MockSubkeyClass,
+        ):
+            MockSecrets.randbelow.return_value = 0x1234
+            mock_kp = MagicMock()
+            mock_kp.public_key = 0x5678
+            MockKeyPair.from_private_key.return_value = mock_kp
+
+            result = p.create_trading_subkey(name="test-key")
+
+        MockSecrets.randbelow.assert_called_once_with(2**251)
+        MockKeyPair.from_private_key.assert_called_once_with(0x1234)
+        mock_api.create_subkey.assert_called_once_with(
+            {"name": "test-key", "public_key": hex(0x5678), "state": "active"}
+        )
+        MockSubkeyClass.assert_called_once_with(
+            env=TESTNET,
+            l2_private_key=hex(0x1234),
+            l2_address=hex(0xDEADBEEF),
+        )
+        assert result is MockSubkeyClass.return_value
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_create_trading_subkey_default_name(self, MockApiClient, MockWsClient, MockEvmAccount):
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        MockEvmAccount.return_value.l2_address = 0xDEADBEEF
+
+        p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY)
+
+        with (
+            patch("paradex_py.paradex_evm.KeyPair") as MockKeyPair,
+            patch("paradex_py.paradex_evm.secrets") as MockSecrets,
+            patch("paradex_py.paradex_subkey.ParadexSubkey"),
+        ):
+            MockSecrets.randbelow.return_value = 0x1234
+            MockKeyPair.from_private_key.return_value.public_key = 0x5678
+            p.create_trading_subkey()
+
+        mock_api.create_subkey.assert_called_once_with(
+            {"name": "trading", "public_key": hex(0x5678), "state": "active"}
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1826,6 +1826,7 @@ version = "0.5.6rc4"
 source = { editable = "." }
 dependencies = [
     { name = "eth-account" },
+    { name = "eth-keys" },
     { name = "httpx" },
     { name = "ledgereth" },
     { name = "marshmallow-dataclass" },
@@ -1858,6 +1859,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "eth-account", specifier = ">=0.13.6" },
+    { name = "eth-keys", specifier = ">=0.6.1" },
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "ledgereth", specifier = ">=0.10.0" },
     { name = "marshmallow-dataclass", specifier = ">=8.6.1,<9.0.0" },


### PR DESCRIPTION
## Summary

- Add `ParadexEvm` client for EVM wallet authentication via SIWE (ERC-4361), enabling users with Ethereum keys to onboard and authenticate without a Starknet key
- Add `EvmAccount` class with deterministic Starknet address derivation (Argent v0.5.0 direct), SIWE message building, and EIP-191 signing
- Add subkey management API methods (`fetch_subkeys`, `create_subkey`, `activate_subkey`, `fetch_subkey`, `update_subkey`, `revoke_subkey`)
- Add token management API methods (`fetch_tokens`, `create_token`, `revoke_token`)
- Add end-to-end example `examples/evm_onboard_and_trade.py` demonstrating the full flow: EVM onboarding → subkey creation → trading via subkey

## Details

- `ParadexEvm` provides `AuthLevel.AUTHENTICATED` (JWT via SIWE, no Starknet signing key); trading requires registering a Starknet subkey and using `ParadexSubkey`
- EVM auth uses v2 endpoints (`/v2/onboarding`, `/v2/auth`) with SIWE domain per environment
- JWT auto-refresh dispatches to `auth_evm()` for EVM accounts
- Added `paraclear_evm_account_hash` to `SystemConfig` (required for address derivation)