### PR TITLE
Onboard using server side address derivation

### DIFF
--- a/examples/server_derived_address.py
+++ b/examples/server_derived_address.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Example: server-side address derivation via ``GET /onboarding``.
+
+By default the SDK derives the L2 Starknet account address client-side using
+``compute_address`` plus the Paraclear class hashes from ``GET /system/config``.
+Passing ``server_derive_address=True`` to ``Paradex(...)`` (or ``ParadexEvm(...)``)
+moves derivation to the server: the SDK calls ``GET /onboarding`` instead and
+uses the returned address. The endpoint also returns ``exists``, which the SDK
+caches to skip ``POST /onboarding`` when the account is already onboarded.
+
+This is useful when:
+  - You don't want the SDK pinned to a specific class-hash scheme.
+  - You want to know up-front whether the account is onboarded
+    (``paradex.is_onboarded``) without triggering an auth round-trip first.
+
+Usage:
+    export L1_ADDRESS="0x..."
+    export L1_PRIVATE_KEY="0x..."
+    python examples/server_derived_address.py
+    # Compare against the local-derivation path:
+    python examples/server_derived_address.py --local
+
+For an EVM wallet:
+    export EVM_PRIVATE_KEY="0x..."
+    python examples/server_derived_address.py --evm
+    python examples/server_derived_address.py --evm --local
+"""
+
+import logging
+import os
+import sys
+
+from eth_account import Account
+
+from paradex_py import Paradex, ParadexEvm
+from paradex_py.environment import NIGHTLY
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _source_label(server_derive_address: bool) -> str:
+    """Tag for log lines so it's obvious which path produced the address."""
+    return "server (GET /onboarding)" if server_derive_address else "local (compute_address)"
+
+
+def starknet_flow(server_derive_address: bool = True) -> None:
+    l1_address = os.getenv("L1_ADDRESS", "")
+    l1_private_key = os.getenv("L1_PRIVATE_KEY", "")
+    if not l1_address or not l1_private_key:
+        sys.exit("Set L1_ADDRESS and L1_PRIVATE_KEY in the environment.")
+
+    paradex = Paradex(
+        env=NIGHTLY,
+        l1_address=l1_address,
+        l1_private_key=l1_private_key,
+        server_derive_address=server_derive_address,
+        logger=logger,
+    )
+
+    # is_onboarded is populated only when the server precheck ran (server_derive_address=True);
+    # otherwise it stays None and the SDK learns onboarding state via the auth retry path.
+    logger.info("L2 address (%s): %s", _source_label(server_derive_address), hex(paradex.account.l2_address))
+    logger.info("Onboarded (cached from precheck): %s", paradex.is_onboarded)
+
+    summary = paradex.api_client.fetch_account_summary()
+    logger.info("Account summary: %s", summary)
+
+
+def evm_flow(server_derive_address: bool = True) -> None:
+    evm_private_key = os.getenv("EVM_PRIVATE_KEY", "")
+    if not evm_private_key:
+        sys.exit("Set EVM_PRIVATE_KEY in the environment.")
+
+    evm_address = Account.from_key(evm_private_key).address
+
+    paradex = ParadexEvm(
+        env=NIGHTLY,
+        evm_address=evm_address,
+        evm_private_key=evm_private_key,
+        server_derive_address=server_derive_address,
+    )
+
+    logger.info("L2 address (%s): %s", _source_label(server_derive_address), hex(paradex.account.l2_address))
+    logger.info("Onboarded (cached from precheck): %s", paradex.is_onboarded)
+
+    balances = paradex.api_client.fetch_balances()
+    logger.info("Balances: %s", balances)
+
+
+if __name__ == "__main__":
+    # `--local` runs the same flow with the flag off, for side-by-side comparison.
+    use_server = "--local" not in sys.argv
+    if "--evm" in sys.argv:
+        evm_flow(server_derive_address=use_server)
+    else:
+        starknet_flow(server_derive_address=use_server)

--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -7,21 +7,17 @@ from enum import IntEnum
 
 from httpx import AsyncClient
 from starknet_py.common import int_from_bytes, int_from_hex
-from starknet_py.hash.address import compute_address
-from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.http_client import HttpMethod
-from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 from paradex_py.account.starknet import Account as StarknetAccount
-from paradex_py.account.utils import derive_stark_key, derive_stark_key_from_ledger, flatten_signature
+from paradex_py.account.utils import derive_l2_address_starknet, flatten_signature, resolve_l2_keypair
 from paradex_py.api.models import SystemConfig
 from paradex_py.common.order import Order
 from paradex_py.message.auth import build_auth_message, build_fullnode_message
 from paradex_py.message.block_trades import BlockTrade, build_block_trade_message
 from paradex_py.message.onboarding import build_onboarding_message
 from paradex_py.message.order import build_modify_order_message, build_order_message
-from paradex_py.message.stark_key import build_stark_key_message
 from paradex_py.utils import raise_value_error
 
 FULLNODE_SIGNATURE_VERSION = "1.0.0"
@@ -63,6 +59,8 @@ class ParadexAccount:
         l1_private_key: str | None = None,
         l2_private_key: str | None = None,
         rpc_version: str | None = None,
+        l2_address: str | None = None,
+        is_onboarded: bool | None = None,
     ):
         self.config = config
 
@@ -72,19 +70,26 @@ class ParadexAccount:
 
         if l1_private_key is not None:
             self.l1_private_key = int_from_hex(l1_private_key)
-            stark_key_msg = build_stark_key_message(int(config.l1_chain_id))
-            self.l2_private_key = derive_stark_key(self.l1_private_key, stark_key_msg)
-        elif l1_private_key_from_ledger:
-            stark_key_msg = build_stark_key_message(int(config.l1_chain_id))
-            self.l2_private_key = derive_stark_key_from_ledger(l1_address, stark_key_msg)
-        elif l2_private_key is not None:
-            self.l2_private_key = int_from_hex(l2_private_key)
-        else:
-            raise_value_error("Paradex: Provide Ethereum or Paradex private key")
 
-        key_pair = KeyPair.from_private_key(self.l2_private_key)
+        key_pair = resolve_l2_keypair(
+            config=config,
+            l1_address=l1_address,
+            l1_private_key=l1_private_key,
+            l1_private_key_from_ledger=bool(l1_private_key_from_ledger),
+            l2_private_key=l2_private_key,
+        )
+        self.l2_private_key = key_pair.private_key
         self.l2_public_key = key_pair.public_key
-        self.l2_address = self._account_address()
+        if l2_address is not None:
+            self.l2_address = int_from_hex(l2_address)
+        else:
+            # Backwards-compat fallback: callers that construct ParadexAccount directly
+            # (without going through the Paradex orchestrator) still get their address
+            # derived for them. The Paradex orchestrator always resolves the address
+            # outside via the same helper, so this branch is only hit for direct
+            # construction and is intended for eventual removal.
+            self.l2_address = derive_l2_address_starknet(config, self.l2_public_key)
+        self.is_onboarded = is_onboarded
 
         # Create starknet account
         if rpc_version:
@@ -133,22 +138,6 @@ class ParadexAccount:
             return await response.json()
 
         client._client._make_request = types.MethodType(monkey_patched_make_request, client._client)
-
-    def _account_address(self) -> int:
-        calldata = [
-            int_from_hex(self.config.paraclear_account_hash),
-            get_selector_from_name("initialize"),
-            2,
-            self.l2_public_key,
-            0,
-        ]
-
-        address = compute_address(
-            class_hash=int_from_hex(self.config.paraclear_account_proxy_hash),
-            constructor_calldata=calldata,
-            salt=self.l2_public_key,
-        )
-        return address
 
     def set_jwt_token(self, jwt_token: str) -> None:
         self.jwt_token = jwt_token

--- a/paradex_py/account/evm_account.py
+++ b/paradex_py/account/evm_account.py
@@ -6,8 +6,8 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_keys import keys as eth_keys
 from starknet_py.common import int_from_hex
-from starknet_py.hash.address import compute_address
 
+from paradex_py.account.utils import derive_l2_address_eip191
 from paradex_py.api.models import SystemConfig
 from paradex_py.environment import Environment
 from paradex_py.utils import raise_value_error
@@ -51,9 +51,9 @@ class EvmAccount:
         env: Environment,
         evm_address: str,
         evm_private_key: str,
+        l2_address: str | None = None,
+        is_onboarded: bool | None = None,
     ):
-        if not config.paraclear_evm_account_hash:
-            raise_value_error("EvmAccount: paraclear_evm_account_hash not available in system config")
         if not evm_address:
             raise_value_error("EvmAccount: EVM address is required")
         if not evm_private_key:
@@ -71,31 +71,16 @@ class EvmAccount:
         _priv_key_obj = eth_keys.PrivateKey(bytes(self._eth_account.key))
         self.evm_public_key_uncompressed = "0x04" + _priv_key_obj.public_key.to_bytes().hex()
 
-        # Derive Starknet address — Argent v0.5.0 direct (no proxy)
-        self.l2_address = self._compute_starknet_address()
-
-    # ------------------------------------------------------------------
-    # Starknet address derivation
-    # ------------------------------------------------------------------
-
-    def _compute_starknet_address(self) -> int:
-        """Derive the Starknet address from the EVM address.
-
-        Uses Argent v0.5.0 direct deployment with EIP-191 signer type:
-          calldata = [3 (Eip191 variant), eth_address, 1 (Option::None guardian)]
-          salt     = eth_address
-          deployer = 0
-        """
-        # paraclear_evm_account_hash is guaranteed non-None by __init__ guard
-        evm_class_hash: str = self.config.paraclear_evm_account_hash  # type: ignore[assignment]
-        eth_addr_int = int_from_hex(self.evm_address)
-        calldata = [3, eth_addr_int, 1]
-        return compute_address(
-            class_hash=int_from_hex(evm_class_hash),
-            constructor_calldata=calldata,
-            salt=eth_addr_int,
-            deployer_address=0,
-        )
+        if l2_address is not None:
+            self.l2_address = int_from_hex(l2_address)
+        else:
+            # Backwards-compat fallback: callers that construct EvmAccount directly
+            # (without going through the ParadexEvm orchestrator) still get their
+            # address derived for them. The orchestrator always resolves the address
+            # outside via the same helper, so this branch is only hit for direct
+            # construction and is intended for eventual removal.
+            self.l2_address = derive_l2_address_eip191(config, self.evm_address)
+        self.is_onboarded = is_onboarded
 
     # ------------------------------------------------------------------
     # SIWE helpers

--- a/paradex_py/account/subkey_account.py
+++ b/paradex_py/account/subkey_account.py
@@ -52,6 +52,11 @@ class SubkeyAccount(ParadexAccount):
         # Set L2 credentials
         self.l2_private_key = int_from_hex(l2_private_key)
         self.l2_address = int_from_hex(l2_address)
+        # A subkey can only be created against an already-onboarded parent account, so by
+        # construction it is onboarded. This skips the NOT_ONBOARDED retry branch in
+        # api_client.init_account() — that retry would fail anyway because
+        # `SubkeyAccount.onboarding_headers()` returns {} (subkeys cannot self-onboard).
+        self.is_onboarded: bool | None = True
 
         # Generate public key from private key
         key_pair = KeyPair.from_private_key(self.l2_private_key)

--- a/paradex_py/account/utils.py
+++ b/paradex_py/account/utils.py
@@ -1,7 +1,7 @@
 import functools
 import hashlib
 from collections.abc import Sequence
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from eth_account import Account
 from eth_account.messages import SignableMessage, encode_typed_data
@@ -14,9 +14,15 @@ from starknet_crypto_py import sign as rs_sign
 from starknet_crypto_py import verify as rs_verify
 from starknet_py.common import int_from_hex
 from starknet_py.constants import EC_ORDER
+from starknet_py.hash.address import compute_address
+from starknet_py.hash.selector import get_selector_from_name
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.utils.typed_data import TypedData, TypedDataDict
 
 from paradex_py.utils import raise_value_error
+
+if TYPE_CHECKING:
+    from paradex_py.api.models import SystemConfig
 
 SHA256_EC_MAX_DIGEST = 2**256
 
@@ -87,6 +93,78 @@ def derive_stark_key_from_ledger(eth_account_address: str, stark_key_msg: TypedD
     message_signature = _sign_stark_key_message_ledger(signable_message, eth_account_address)
     l2_private_key = _get_private_key_from_eth_signature(message_signature)
     return l2_private_key
+
+
+def derive_l2_address_starknet(config: "SystemConfig", l2_public_key: int) -> int:
+    """Compute the Paraclear L2 account address from the L2 public key.
+
+    Mirrors the ``/onboarding`` endpoint's server-side derivation for Starknet-keyed
+    accounts: proxy deployment with ``initialize(public_key, 0)`` calldata.
+    Shared by ``Paradex.init_account()`` (primary caller) and
+    ``ParadexAccount.__init__`` (backwards-compat fallback for direct construction).
+    """
+    calldata = [
+        int_from_hex(config.paraclear_account_hash),
+        get_selector_from_name("initialize"),
+        2,
+        l2_public_key,
+        0,
+    ]
+    return compute_address(
+        class_hash=int_from_hex(config.paraclear_account_proxy_hash),
+        constructor_calldata=calldata,
+        salt=l2_public_key,
+    )
+
+
+def derive_l2_address_eip191(config: "SystemConfig", evm_address: str) -> int:
+    """Compute the Paraclear L2 account address from an EVM (EIP-191) address.
+
+    Mirrors the ``/onboarding`` endpoint's server-side derivation for EIP-191-keyed
+    accounts: Argent v0.5.0 direct deployment (no proxy) with EIP-191 signer variant.
+    Shared by ``ParadexEvm.__init__`` (primary caller) and ``EvmAccount.__init__``
+    (backwards-compat fallback for direct construction).
+    """
+    if not config.paraclear_evm_account_hash:
+        raise_value_error("paraclear_evm_account_hash not available in system config")
+    eth_addr_int = int_from_hex(evm_address)
+    return compute_address(
+        class_hash=int_from_hex(config.paraclear_evm_account_hash),
+        constructor_calldata=[3, eth_addr_int, 1],
+        salt=eth_addr_int,
+        deployer_address=0,
+    )
+
+
+def resolve_l2_keypair(
+    config: "SystemConfig",
+    l1_address: str,
+    l1_private_key: str | None = None,
+    l1_private_key_from_ledger: bool = False,
+    l2_private_key: str | None = None,
+) -> KeyPair:
+    """Resolve the L2 Starknet keypair from whichever credential the caller supplied.
+
+    Mirrors the credential-selection logic used internally by ``ParadexAccount``:
+    an L1 private key derives an L2 key via the STARK-key typed-data message; a
+    Ledger-backed L1 key does the same through the hardware wallet; an L2 private
+    key is used directly. Exposed as a helper so callers (e.g. ``Paradex``) can
+    compute the public key needed by public endpoints such as ``GET /onboarding``
+    before the account object itself is constructed.
+    """
+    from paradex_py.message.stark_key import build_stark_key_message
+
+    if l1_private_key is not None:
+        stark_key_msg = build_stark_key_message(int(config.l1_chain_id))
+        private_key = derive_stark_key(int_from_hex(l1_private_key), stark_key_msg)
+    elif l1_private_key_from_ledger:
+        stark_key_msg = build_stark_key_message(int(config.l1_chain_id))
+        private_key = derive_stark_key_from_ledger(l1_address, stark_key_msg)
+    elif l2_private_key is not None:
+        private_key = int_from_hex(l2_private_key)
+    else:
+        raise_value_error("Paradex: Provide Ethereum or Paradex private key")
+    return KeyPair.from_private_key(private_key)
 
 
 def flatten_signature(sig: list[int]) -> str:

--- a/paradex_py/api/api_client.py
+++ b/paradex_py/api/api_client.py
@@ -125,7 +125,18 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
 
     def init_account(self, account: ParadexAccount):
         self.account = account
-        if self.auto_auth:
+        if not self.auto_auth:
+            return
+        is_onboarded = getattr(account, "is_onboarded", None)
+        if is_onboarded is True:
+            # Server precheck confirmed account is onboarded — skip POST /onboarding.
+            self.auth(params=self.auth_params)
+        elif is_onboarded is False:
+            # Server precheck confirmed account is NOT onboarded — POST first, then auth.
+            self.onboarding()
+            self.auth(params=self.auth_params)
+        else:
+            # No precheck ran (local-derivation path) — fall back to the retry-on-error dance.
             try:
                 self.auth(params=self.auth_params)
             except ValueError as e:
@@ -183,7 +194,15 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         """Initialize an EVM account and run the v2 onboarding/auth flow."""
         self._evm_account = account
         self._is_evm_account = True
-        if self.auto_auth:
+        if not self.auto_auth:
+            return
+        is_onboarded = getattr(account, "is_onboarded", None)
+        if is_onboarded is True:
+            self.auth_evm(params=self.auth_params)
+        elif is_onboarded is False:
+            self.onboarding_evm()
+            self.auth_evm(params=self.auth_params)
+        else:
             try:
                 self.auth_evm(params=self.auth_params)
             except ValueError as e:

--- a/paradex_py/paradex.py
+++ b/paradex_py/paradex.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from paradex_py._client_base import _ClientBase
 from paradex_py.account.account import ParadexAccount
+from paradex_py.account.utils import derive_l2_address_starknet, resolve_l2_keypair
 from paradex_py.api.api_client import ParadexApiClient
 from paradex_py.api.protocols import DefaultRetryStrategy
 from paradex_py.api.ws_client import ParadexWebsocketClient
@@ -62,6 +63,9 @@ class Paradex(_ClientBase):
         signer (Signer, optional): Custom order signer for submit/modify/batch operations. Defaults to None.
         rpc_version (str, optional): RPC version (e.g., "v0_9"). If provided, constructs URL as {base_url}/rpc/{rpc_version}. Defaults to None.
         config (SystemConfig, optional): System configuration. If provided, uses this config instead of fetching from API. Defaults to None.
+        server_derive_address (bool, optional): When True, fetch the L2 address from ``GET /onboarding`` instead of
+            computing it locally from class hashes. Also caches the ``exists`` flag so ``POST /onboarding`` is skipped
+            when the account is already onboarded. Defaults to False (local ``compute_address`` path unchanged).
 
     Examples:
         >>> from paradex_py import Paradex
@@ -112,10 +116,13 @@ class Paradex(_ClientBase):
         # RPC configuration
         rpc_version: str | None = None,
         config: "SystemConfig | None" = None,
+        # Onboarding configuration
+        server_derive_address: bool = False,
     ):
         _validate_env(env, "Paradex")
         self.env = env
         self.logger: logging.Logger = logger or logging.getLogger(__name__)
+        self.server_derive_address = server_derive_address
 
         # Create enhanced HTTP client if needed (retry_strategy is handled by ParadexApiClient directly)
         if http_client is None and (default_timeout or request_hook or not enable_http_compression):
@@ -213,12 +220,42 @@ class Paradex(_ClientBase):
         """
         if self.account is not None:
             raise_value_error("Paradex: Account already initialized")
-        self.account = ParadexAccount(
+
+        # Resolve the L2 keypair once, up-front. This avoids double-triggering the EIP-712
+        # stark-key signature (or worse: a second Ledger prompt) when the account
+        # constructor would otherwise re-resolve from the same credentials.
+        key_pair = resolve_l2_keypair(
             config=self.config,
             l1_address=l1_address,
             l1_private_key=l1_private_key,
             l1_private_key_from_ledger=l1_private_key_from_ledger,
             l2_private_key=l2_private_key,
+        )
+
+        # Derive the L2 address outside the account constructor — either from the server
+        # (GET /onboarding) or from the shared local helper. Both paths converge to a
+        # single downstream ParadexAccount(...) call with a pre-resolved address.
+        # getattr fallback protects callers that bypass __init__ via Paradex.__new__(...).
+        is_onboarded: bool | None = None
+        if getattr(self, "server_derive_address", False):
+            info = self.api_client.fetch_onboarding(
+                {
+                    "account_signer_type": "starknet",
+                    "public_key": hex(key_pair.public_key),
+                }
+            )
+            l2_address_hex: str = info["address"]
+            exists = info.get("exists")
+            is_onboarded = bool(exists) if exists is not None else None
+        else:
+            l2_address_hex = hex(derive_l2_address_starknet(self.config, key_pair.public_key))
+
+        self.account = ParadexAccount(
+            config=self.config,
+            l1_address=l1_address,
+            l2_private_key=hex(key_pair.private_key),
+            l2_address=l2_address_hex,
+            is_onboarded=is_onboarded,
             rpc_version=rpc_version,
         )
         self.api_client.init_account(self.account)
@@ -257,3 +294,12 @@ class Paradex(_ClientBase):
         """``True`` when account is initialized — full account key, all on-chain operations
         available (deposit, withdraw, transfer)."""
         return self.account is not None
+
+    @property
+    def is_onboarded(self) -> bool | None:
+        """Cached onboarding state from ``GET /onboarding``.
+
+        Returns ``True`` / ``False`` when ``server_derive_address=True`` populated the cache at
+        account initialization, ``None`` otherwise (local derivation path — the SDK learns
+        onboarding status lazily via the ``NOT_ONBOARDED`` auth-retry flow)."""
+        return self.account.is_onboarded if self.account is not None else None

--- a/paradex_py/paradex_evm.py
+++ b/paradex_py/paradex_evm.py
@@ -2,10 +2,12 @@ import logging
 import secrets
 from typing import TYPE_CHECKING
 
+from eth_account import Account as EthAccount
 from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 from paradex_py._client_base import _ClientBase
 from paradex_py.account.evm_account import EvmAccount
+from paradex_py.account.utils import derive_l2_address_eip191
 from paradex_py.api.api_client import ParadexApiClient
 from paradex_py.api.ws_client import ParadexWebsocketClient
 from paradex_py.auth_level import AuthLevel
@@ -36,6 +38,11 @@ class ParadexEvm(_ClientBase):
         ws_enabled (bool, optional): Whether to create a WebSocket client. Defaults to True.
             Set to False for REST-only use cases.
         ws_sbe_enabled (bool, optional): Enable SBE encoding on WebSocket. Defaults to False.
+        server_derive_address (bool, optional): When True, fetch the L2 address from
+            ``GET /onboarding`` (signer type ``eip191``) instead of deriving it locally from
+            ``paraclear_evm_account_hash``. Also caches the ``exists`` flag so
+            ``POST /v2/onboarding`` is skipped when the account is already onboarded. Defaults
+            to False (local derivation path unchanged).
 
     Examples:
         >>> from paradex_py import ParadexEvm
@@ -64,6 +71,7 @@ class ParadexEvm(_ClientBase):
         ws_timeout: int | None = None,
         ws_enabled: bool = True,
         ws_sbe_enabled: bool = False,
+        server_derive_address: bool = False,
     ):
         _validate_env(env, "ParadexEvm")
 
@@ -74,6 +82,7 @@ class ParadexEvm(_ClientBase):
 
         self.env = env
         self.logger: logging.Logger = logger or logging.getLogger(__name__)
+        self.server_derive_address = server_derive_address
 
         self.api_client = ParadexApiClient(env=env, logger=logger)
         self.ws_client: ParadexWebsocketClient | None = (
@@ -89,11 +98,33 @@ class ParadexEvm(_ClientBase):
         )
         self.config = self.api_client.fetch_system_config()
 
+        # Derive the L2 address outside the EvmAccount constructor — either from the
+        # server (GET /onboarding) or from the shared local helper. Both paths converge
+        # to a single downstream EvmAccount(...) call with a pre-resolved address.
+        # `EthAccount.from_key(...)` normalises the address to checksum format, which is
+        # what both the ``/onboarding`` endpoint and the local derivation helper expect.
+        checksum_address = EthAccount.from_key(evm_private_key).address
+        is_onboarded: bool | None = None
+        if server_derive_address:
+            info = self.api_client.fetch_onboarding(
+                {
+                    "account_signer_type": "eip191",
+                    "eth_address": checksum_address,
+                }
+            )
+            l2_address_hex: str = info["address"]
+            exists = info.get("exists")
+            is_onboarded = bool(exists) if exists is not None else None
+        else:
+            l2_address_hex = hex(derive_l2_address_eip191(self.config, checksum_address))
+
         self.account = EvmAccount(
             config=self.config,
             env=env,
             evm_address=evm_address,
             evm_private_key=evm_private_key,
+            l2_address=l2_address_hex,
+            is_onboarded=is_onboarded,
         )
 
         self.api_client.init_account_evm(self.account)
@@ -119,6 +150,14 @@ class ParadexEvm(_ClientBase):
         """Always ``True`` — the L2 account is owned by the EVM key; on-chain
         operations (deposit, withdraw, transfer) are supported."""
         return True
+
+    @property
+    def is_onboarded(self) -> bool | None:
+        """Cached onboarding state from ``GET /onboarding``.
+
+        Returns ``True`` / ``False`` when ``server_derive_address=True`` populated the cache at
+        construction, ``None`` otherwise (local derivation path)."""
+        return self.account.is_onboarded if self.account is not None else None
 
     def create_trading_subkey(self, name: str = "trading") -> "ParadexSubkey":
         """Generate a fresh Starknet subkey, register it, and return a ready-to-trade client.

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -184,3 +184,45 @@ def test_subkey_account_with_subkey_auth_signature():
         unflatten_signature(sig),
         subkey_pair.public_key,  # verified with subkey's public key
     )
+
+
+# ---------------------------------------------------------------------------
+# ParadexAccount: server-derived l2_address (GET /onboarding path)
+# ---------------------------------------------------------------------------
+
+
+def test_paradex_account_with_server_derived_address_skips_local_derivation():
+    """When l2_address is supplied, ParadexAccount must use it verbatim and skip
+    compute_address (the class-hash-based local derivation). A deliberately-wrong
+    address proves local derivation did not run."""
+    config = MockApiClient().fetch_system_config()
+    # An address that cannot result from local derivation of TEST_L2_PRIVATE_KEY.
+    server_address = "0xdeadbeef"
+
+    account = ParadexAccount(
+        config=config,
+        l1_address=TEST_L1_ADDRESS,
+        l2_private_key=TEST_L2_PRIVATE_KEY,
+        l2_address=server_address,
+        is_onboarded=True,
+    )
+
+    assert account.l2_address == int_from_hex(server_address)
+    assert account.starknet.address == int_from_hex(server_address)
+    assert account.is_onboarded is True
+    # Keys are still resolved locally — only the address comes from the caller.
+    assert account.l2_public_key == TEST_L2_PUBLIC_KEY
+
+
+def test_paradex_account_default_still_derives_locally():
+    """Regression guard: without l2_address kwarg, behavior is unchanged."""
+    config = MockApiClient().fetch_system_config()
+
+    account = ParadexAccount(
+        config=config,
+        l1_address=TEST_L1_ADDRESS,
+        l2_private_key=TEST_L2_PRIVATE_KEY,
+    )
+
+    assert account.l2_address == TEST_L2_ADDRESS
+    assert account.is_onboarded is None

--- a/tests/api/test_auth_enhancements.py
+++ b/tests/api/test_auth_enhancements.py
@@ -228,6 +228,61 @@ class TestAuthenticationEnhancements:
             mock_onboarding.assert_not_called()
             mock_auth.assert_not_called()
 
+    @patch.object(ParadexApiClient, "fetch_system_config", return_value=MagicMock())
+    def test_init_account_with_precheck_onboarded_skips_post(self, mock_config):
+        """When account.is_onboarded is True (server precheck), skip POST /onboarding entirely."""
+        client = ParadexApiClient(env=TESTNET, auto_auth=True)
+        mock_account = MagicMock()
+        mock_account.is_onboarded = True
+
+        with patch.object(client, "onboarding") as mock_onboarding, patch.object(client, "auth") as mock_auth:
+            client.init_account(mock_account)
+
+            mock_onboarding.assert_not_called()
+            mock_auth.assert_called_once_with(params=None)
+
+    @patch.object(ParadexApiClient, "fetch_system_config", return_value=MagicMock())
+    def test_init_account_with_precheck_not_onboarded_posts_then_auths(self, mock_config):
+        """When account.is_onboarded is False (server precheck), POST /onboarding before auth
+        without relying on the NOT_ONBOARDED exception dance."""
+        client = ParadexApiClient(env=TESTNET, auto_auth=True)
+        mock_account = MagicMock()
+        mock_account.is_onboarded = False
+
+        with patch.object(client, "onboarding") as mock_onboarding, patch.object(client, "auth") as mock_auth:
+            client.init_account(mock_account)
+
+            mock_onboarding.assert_called_once()
+            mock_auth.assert_called_once_with(params=None)
+            # Exactly one auth call — no retry
+            assert mock_auth.call_count == 1
+
+    @patch.object(ParadexApiClient, "fetch_system_config", return_value=MagicMock())
+    def test_init_account_evm_with_precheck_onboarded_skips_post(self, mock_config):
+        """EVM variant: precheck True skips POST /v2/onboarding."""
+        client = ParadexApiClient(env=TESTNET, auto_auth=True)
+        mock_account = MagicMock()
+        mock_account.is_onboarded = True
+
+        with patch.object(client, "onboarding_evm") as mock_onboarding, patch.object(client, "auth_evm") as mock_auth:
+            client.init_account_evm(mock_account)
+
+            mock_onboarding.assert_not_called()
+            mock_auth.assert_called_once_with(params=None)
+
+    @patch.object(ParadexApiClient, "fetch_system_config", return_value=MagicMock())
+    def test_init_account_evm_with_precheck_not_onboarded_posts_then_auths(self, mock_config):
+        """EVM variant: precheck False posts then auths (no exception dance)."""
+        client = ParadexApiClient(env=TESTNET, auto_auth=True)
+        mock_account = MagicMock()
+        mock_account.is_onboarded = False
+
+        with patch.object(client, "onboarding_evm") as mock_onboarding, patch.object(client, "auth_evm") as mock_auth:
+            client.init_account_evm(mock_account)
+
+            mock_onboarding.assert_called_once()
+            assert mock_auth.call_count == 1
+
 
 class TestSigningEnhancements:
     """Test signing enhancements."""

--- a/tests/mocks/api_client.py
+++ b/tests/mocks/api_client.py
@@ -29,9 +29,40 @@ MOCK_CONFIG = {
 }
 
 
+MOCK_ONBOARDING_STARKNET = {
+    "account_signer_type": "starknet",
+    "address": "0x129c135ed63df9353885e292be4426b8ed6122b13c6c0e1bb787288a1f5adfa",
+    "exists": True,
+    "derivation_info": {
+        "class_hash": "0x41cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e",
+        "proxy_class_hash": "0x3530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9",
+    },
+}
+
+MOCK_ONBOARDING_EIP191 = {
+    "account_signer_type": "eip191",
+    "address": "0x7d32afc77ded2e21821e2db7474183131f3d9de0da94ffbb4111efe5b91e37a",
+    "exists": True,
+    "derivation_info": {
+        "class_hash": "0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2",
+    },
+}
+
+
 class MockApiClient:
+    def __init__(self, onboarding_response: dict | None = None):
+        # Default to the starknet fixture; callers can override per-test with either
+        # MOCK_ONBOARDING_EIP191 or a custom dict (e.g. exists=False variants).
+        self._onboarding_response = onboarding_response or MOCK_ONBOARDING_STARKNET
+        self.fetch_onboarding_calls: list[dict | None] = []
+
     def fetch_system_config(self) -> SystemConfig:
         return SystemConfigSchema().load(MOCK_CONFIG)
+
+    def fetch_onboarding(self, params: dict | None = None) -> dict:
+        """Mock GET /onboarding returning a canned response."""
+        self.fetch_onboarding_calls.append(params)
+        return dict(self._onboarding_response)
 
     def init_account(self, account):
         """Mock init_account method for testing."""

--- a/tests/test_auth_modes.py
+++ b/tests/test_auth_modes.py
@@ -584,10 +584,11 @@ class TestClosePartialInit:
 
 
 class TestParadexEvm:
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_successful_init(self, MockApiClient, MockWsClient, MockEvmAccount):
+    def test_successful_init(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive):
         mock_api = MockApiClient.return_value
         mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
 
@@ -595,29 +596,34 @@ class TestParadexEvm:
 
         MockApiClient.assert_called_once_with(env=TESTNET, logger=None)
         mock_api.fetch_system_config.assert_called_once()
+        # Orchestrator derives outside, then hands the pre-resolved address to EvmAccount.
         MockEvmAccount.assert_called_once_with(
             config=MOCK_SYSTEM_CONFIG,
             env=TESTNET,
             evm_address=EVM_ADDR,
             evm_private_key=EVM_KEY,
+            l2_address=hex(0xABC),
+            is_onboarded=None,
         )
         mock_api.init_account_evm.assert_called_once_with(MockEvmAccount.return_value)
         assert p.config is MOCK_SYSTEM_CONFIG
 
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_ws_timeout_forwarded(self, MockApiClient, MockWsClient, MockEvmAccount):
+    def test_ws_timeout_forwarded(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive):
         MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
         ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY, ws_timeout=42)
         MockWsClient.assert_called_once_with(
             env=TESTNET, logger=None, ws_timeout=42, api_client=MockApiClient.return_value, sbe_enabled=False
         )
 
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_ws_enabled_false_skips_ws_client(self, MockApiClient, MockWsClient, MockEvmAccount):
+    def test_ws_enabled_false_skips_ws_client(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive):
         MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
         p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY, ws_enabled=False)
         MockWsClient.assert_not_called()
@@ -639,10 +645,11 @@ class TestParadexEvm:
         with pytest.raises(ValueError):
             ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key="")
 
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_capabilities(self, MockApiClient, MockWsClient, MockEvmAccount):
+    def test_capabilities(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive):
         """Full account: withdraw yes, trade no (needs subkey), auth FULL."""
         MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
         p = ParadexEvm(env=TESTNET, evm_address=EVM_ADDR, evm_private_key=EVM_KEY)
@@ -651,10 +658,13 @@ class TestParadexEvm:
         assert p.can_trade is False
         assert p.can_withdraw is True
 
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_create_trading_subkey_registers_and_returns_subkey(self, MockApiClient, MockWsClient, MockEvmAccount):
+    def test_create_trading_subkey_registers_and_returns_subkey(
+        self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive
+    ):
         mock_api = MockApiClient.return_value
         mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
         MockEvmAccount.return_value.l2_address = 0xDEADBEEF
@@ -685,10 +695,11 @@ class TestParadexEvm:
         )
         assert result is MockSubkeyClass.return_value
 
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_create_trading_subkey_default_name(self, MockApiClient, MockWsClient, MockEvmAccount):
+    def test_create_trading_subkey_default_name(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive):
         mock_api = MockApiClient.return_value
         mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
         MockEvmAccount.return_value.l2_address = 0xDEADBEEF
@@ -706,6 +717,51 @@ class TestParadexEvm:
 
         mock_api.create_subkey.assert_called_once_with(
             {"name": "trading", "public_key": hex(0x5678), "state": "active"}
+        )
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_server_derive_address_calls_onboarding_and_passes_through(
+        self, MockApiClient, MockWsClient, MockEvmAccount
+    ):
+        """When server_derive_address=True, ParadexEvm hits GET /onboarding (eip191) and
+        forwards the server-returned address + exists flag to EvmAccount."""
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        mock_api.fetch_onboarding.return_value = {
+            "account_signer_type": "eip191",
+            "address": "0xabc123",
+            "exists": True,
+            "derivation_info": {"class_hash": "0x73414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2"},
+        }
+
+        ParadexEvm(
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            server_derive_address=True,
+        )
+
+        # GET /onboarding called with eth_address (checksum) and eip191 signer type.
+        mock_api.fetch_onboarding.assert_called_once()
+        params = mock_api.fetch_onboarding.call_args[0][0]
+        assert params["account_signer_type"] == "eip191"
+        # The `eth_address` is derived from the private key (checksum form), not the caller's
+        # evm_address param — that's what the server needs for deterministic derivation.
+        from eth_account import Account as _EthAccount
+
+        expected = _EthAccount.from_key(EVM_KEY).address
+        assert params["eth_address"] == expected
+
+        # Server-derived address + is_onboarded flag flow into EvmAccount.
+        MockEvmAccount.assert_called_once_with(
+            config=MOCK_SYSTEM_CONFIG,
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            l2_address="0xabc123",
+            is_onboarded=True,
         )
 
 


### PR DESCRIPTION
Since nightly has moved to the new address derivation method, we no longer support the legacy client side adderss derivation that supports both the account class hash and proxy.

Adds option to use server side address derivation so we can still use paradex-py on nightly (and eventually testnet)

- Account structs now take in 'address' and 'onboarded'
- Orchestrators (Paradex/ ParadexEVM) now fork on whether users specify `server_derive_address` (Defaults to false for backward compatibility). If true, performs the server side address derivation process (calls GET /onboarding to determine address)
- Added examples and tests for this.