### PR TITLE
Add Pending Settlement status to Block Trades

### DIFF
--- a/paradex_py/api/generated/responses.py
+++ b/paradex_py/api/generated/responses.py
@@ -291,6 +291,7 @@ class BlockTradeStatus(str, Enum):
     block_trade_status_completed = "COMPLETED"
     block_trade_status_failed = "FAILED"
     block_trade_status_cancelled = "CANCELLED"
+    block_trade_status_pending_settlement = "PENDING_SETTLEMENT"
 
 
 class BlockTradeType(str, Enum):


### PR DESCRIPTION
Block Trades transition Pending Settlement status when submitted to the
chain for the final settlement.
This is the status before transitioning to Complete