### PR TITLE
Block Trade signature

### DIFF
--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -225,8 +225,8 @@ class ParadexAccount:
         return flatten_signature(sig)
 
     def _build_block_trade_signature_dto(self, signature_data: str, nonce: str, expiration: int) -> BlockTradeSignature:
-        """Construct the BlockTradeSignature DTO with the metadata fields the server
-        expects. Single source of truth for the DTO shape so build_block_trade_signature
+        """Construct the BlockTradeSignature with the metadata fields the server
+        expects. Single source of truth to build_block_trade_signature
         and build_block_trade_offer_signature stay aligned if the schema evolves
         (e.g. a new field added to BlockTradeSignature must not be forgotten in one path).
         """

--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -12,13 +12,20 @@ from starknet_py.net.http_client import HttpMethod
 
 from paradex_py.account.starknet import Account as StarknetAccount
 from paradex_py.account.utils import derive_l2_address_starknet, flatten_signature, resolve_l2_keypair
+from paradex_py.api.generated.responses import BlockTradeDetailFullResponse, BlockTradeSignature, SignatureType
 from paradex_py.api.models import SystemConfig
 from paradex_py.common.order import Order
 from paradex_py.message.auth import build_auth_message, build_fullnode_message
-from paradex_py.message.block_trades import BlockTrade, build_block_trade_message
+from paradex_py.message.block_trades import (
+    BlockTrade,
+    BlockTradeOffer,
+    block_trade_from_response,
+    build_block_trade_message,
+    build_block_trade_offer_message,
+)
 from paradex_py.message.onboarding import build_onboarding_message
 from paradex_py.message.order import build_modify_order_message, build_order_message
-from paradex_py.utils import raise_value_error
+from paradex_py.utils import raise_value_error, time_now_milli_secs
 
 FULLNODE_SIGNATURE_VERSION = "1.0.0"
 
@@ -198,28 +205,110 @@ class ParadexAccount:
         return flatten_signature(sig)
 
     def sign_block_trade(self, block_trade_data: BlockTrade) -> str:
-        """Sign block trade data using Starknet account.
-        Args:
-            block_trade_data (dict): Block trade data containing trade details
-        Returns:
-            dict: Signed block trade data
+        """Sign a BlockTrade and return the flattened "[r,s]" signature string.
+
+        Lower-level entrypoint. Most callers should use `build_block_trade_signature` which
+        returns a complete `BlockTradeSignature` with metadata fields populated.
         """
-        # Convert block trade data to TypedData format
         typed_data = build_block_trade_message(self.l2_chain_id, block_trade_data)
         sig = self.starknet.sign_message(typed_data)
         return flatten_signature(sig)
 
-    def sign_block_offer(self, offer_data: BlockTrade) -> str:
-        """Sign block offer data using Starknet account.
-        Args:
-            offer_data (dict): Block offer data containing offer details
-        Returns:
-            dict: Signed block offer data
+    def sign_block_trade_offer(self, offer: BlockTradeOffer) -> str:
+        """Sign a BlockTradeOffer and return the flattened "[r,s]" signature string.
+
+        Lower-level entrypoint. Most callers should use `build_block_trade_offer_signature`
+        which returns a complete `BlockTradeSignature` with metadata fields populated.
         """
-        # Convert block offer data to TypedData format
-        typed_data = build_block_trade_message(self.l2_chain_id, offer_data)
+        typed_data = build_block_trade_offer_message(self.l2_chain_id, offer)
         sig = self.starknet.sign_message(typed_data)
         return flatten_signature(sig)
+
+    def _build_block_trade_signature_dto(self, signature_data: str, nonce: str, expiration: int) -> BlockTradeSignature:
+        """Construct the BlockTradeSignature DTO with the metadata fields the server
+        expects. Single source of truth for the DTO shape so build_block_trade_signature
+        and build_block_trade_offer_signature stay aligned if the schema evolves
+        (e.g. a new field added to BlockTradeSignature must not be forgotten in one path).
+        """
+        return BlockTradeSignature(
+            nonce=nonce,
+            signature_data=signature_data,
+            signature_expiration=expiration,
+            signature_timestamp=time_now_milli_secs(),
+            signature_type=SignatureType.starknet,
+            signer_account=hex(self.l2_address),
+            signer_public_key=hex(self.l2_public_key),
+        )
+
+    def build_block_trade_offer_signature(self, offer: BlockTradeOffer) -> BlockTradeSignature:
+        """Sign a BlockTradeOffer and return the full `BlockTradeSignature`.
+
+        For the offerer to attach to a `BlockOfferRequest.signature`. Auto-populates
+        `signer_public_key` with the account's signing key (main or active subkey).
+        """
+        return self._build_block_trade_signature_dto(self.sign_block_trade_offer(offer), offer.nonce, offer.expiration)
+
+    def build_block_trade_signature(self, block_trade: BlockTrade) -> BlockTradeSignature:
+        """Sign a BlockTrade and return the full `BlockTradeSignature` ready to attach to a
+        BlockTradeRequest / BlockOfferRequest / BlockExecuteRequest.
+
+        Auto-populates `signer_public_key` with the account's signing key (main account or
+        subkey, depending on which account class instantiated this). The server uses this
+        hint to look up the right pubkey for verification.
+        """
+        return self._build_block_trade_signature_dto(
+            self.sign_block_trade(block_trade), block_trade.nonce, block_trade.expiration
+        )
+
+    def build_executor_signature_for_block(
+        self,
+        block_response: BlockTradeDetailFullResponse,
+        nonce: str | None = None,
+        expiration_minutes: int = 5,
+    ) -> dict[str, BlockTradeSignature]:
+        """Build the executor-side signature for a DIRECT block trade execute.
+
+        Pass the `BlockTradeDetailFullResponse` returned by `get_block_trade()`. Returns a
+        dict ready to assign to `BlockExecuteRequest.signatures` — keyed by block_id with
+        a single entry. The executor (this account) signs the merkle root of the block's
+        trades using a fresh nonce/expiration.
+
+        Use this for direct block trades. For offer-based blocks, use
+        `build_executor_signatures_for_offers` instead.
+        """
+        if not block_response.block_id:
+            raise ValueError("block_response.block_id is required")
+        nonce, expiration = self._executor_nonce_expiration(nonce, expiration_minutes)
+        bt = block_trade_from_response(block_response, nonce, expiration)
+        return {block_response.block_id: self.build_block_trade_signature(bt)}
+
+    def build_executor_signatures_for_offers(
+        self,
+        offer_responses: list[BlockTradeDetailFullResponse],
+        nonce: str | None = None,
+        expiration_minutes: int = 5,
+    ) -> dict[str, BlockTradeSignature]:
+        """Build executor-side signatures for an OFFER-BASED block trade execute.
+
+        Pass a list of `BlockTradeDetailFullResponse` objects (one per offer being
+        accepted, fetched via `get_block_trade_offer()`). Returns a dict keyed by
+        offer_id with one signature per offer — each commits the executor (this account)
+        to that specific offer's trade fills.
+        """
+        nonce, expiration = self._executor_nonce_expiration(nonce, expiration_minutes)
+        sigs: dict[str, BlockTradeSignature] = {}
+        for offer in offer_responses:
+            if not offer.block_id:
+                raise ValueError("each offer_response must have block_id set")
+            bt = block_trade_from_response(offer, nonce, expiration)
+            sigs[offer.block_id] = self.build_block_trade_signature(bt)
+        return sigs
+
+    def _executor_nonce_expiration(self, nonce: str | None, expiration_minutes: int) -> tuple[str, int]:
+        if nonce is None:
+            nonce = str(time.time_ns())
+        expiration = time_now_milli_secs() + expiration_minutes * 60 * 1000
+        return nonce, expiration
 
     async def transfer_on_l2(self, target_l2_address: str, amount_decimal: Decimal):
         try:

--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -225,11 +225,7 @@ class ParadexAccount:
         return flatten_signature(sig)
 
     def _build_block_trade_signature_dto(self, signature_data: str, nonce: str, expiration: int) -> BlockTradeSignature:
-        """Construct the BlockTradeSignature with the metadata fields the server
-        expects. Single source of truth to build_block_trade_signature
-        and build_block_trade_offer_signature stay aligned if the schema evolves
-        (e.g. a new field added to BlockTradeSignature must not be forgotten in one path).
-        """
+        """Construct the BlockTradeSignature with all expected metadata"""
         return BlockTradeSignature(
             nonce=nonce,
             signature_data=signature_data,

--- a/paradex_py/account/account.py
+++ b/paradex_py/account/account.py
@@ -273,7 +273,7 @@ class ParadexAccount:
         `build_executor_signatures_for_offers` instead.
         """
         if not block_response.block_id:
-            raise ValueError("block_response.block_id is required")
+            raise ValueError("block_response.block_id is required")  # noqa: TRY003
         nonce, expiration = self._executor_nonce_expiration(nonce, expiration_minutes)
         bt = block_trade_from_response(block_response, nonce, expiration)
         return {block_response.block_id: self.build_block_trade_signature(bt)}
@@ -295,7 +295,7 @@ class ParadexAccount:
         sigs: dict[str, BlockTradeSignature] = {}
         for offer in offer_responses:
             if not offer.block_id:
-                raise ValueError("each offer_response must have block_id set")
+                raise ValueError("each offer_response must have block_id set")  # noqa: TRY003
             bt = block_trade_from_response(offer, nonce, expiration)
             sigs[offer.block_id] = self.build_block_trade_signature(bt)
         return sigs

--- a/paradex_py/api/generated/responses.py
+++ b/paradex_py/api/generated/responses.py
@@ -281,6 +281,16 @@ class BlockTradeSignature(BaseModel):
     signer_account: Annotated[
         str, Field(description="Starknet account address of the signer", examples=["0x1234567890abcdef"])
     ]
+    signer_public_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Hex stark pubkey used to sign (account main key or active subkey). Empty defaults to account main key."
+            ),
+            examples=["0xabc..."],
+        ),
+    ] = None
 
 
 class BlockTradeStatus(str, Enum):

--- a/paradex_py/api/generated/responses.py
+++ b/paradex_py/api/generated/responses.py
@@ -279,14 +279,14 @@ class BlockTradeSignature(BaseModel):
         SignatureType, Field(description="Type of cryptographic signature used", examples=["STARKNET"])
     ]
     signer_account: Annotated[
-        str, Field(description="Starknet account address of the signer", examples=["0x1234567890abcdef"])
+        str, Field(description="Paradex account address of the signer", examples=["0x1234567890abcdef"])
     ]
     signer_public_key: Annotated[
         str | None,
         Field(
             default=None,
             description=(
-                "Hex stark pubkey used to sign (account main key or active subkey). Empty defaults to account main key."
+                "Hex pubkey used to sign (main account key or active subkey). Empty defaults to account main key."
             ),
             examples=["0xabc..."],
         ),

--- a/paradex_py/message/block_trades.py
+++ b/paradex_py/message/block_trades.py
@@ -15,10 +15,10 @@ BLOCK_TRADE_PAYLOAD_VERSION = "2"
 
 
 class BlockTradeOrder:
-    """Order-side component of a Trade leaf. Distinct from the rev0 Order used for
-    standalone order signing: drops timestamp (replay protection lives at block level)
-    and market (lives at Trade level), but includes account explicitly since a Trade
-    leaf may carry orders from different participants.
+    """Order-side component of a Trade. Distinct from the rev0 Order used for standalone
+    order signing: drops timestamp (replay protection lives at block level) and market
+    (lives at Trade level), but includes account explicitly since a Trade may carry orders
+    from different participants.
     """
 
     def __init__(
@@ -37,7 +37,7 @@ class BlockTradeOrder:
 
 
 class Trade:
-    """One leaf of the block-trade merkle tree.
+    """One trade in a block — becomes a single leaf of the merkle tree at signing time.
 
     A Trade carries either fill data (for direct/offer trades) or constraint data (for
     offer-based parent blocks where only bounds are agreed at create time). Both variants
@@ -78,7 +78,7 @@ class Trade:
         maker_order: BlockTradeOrder,
         taker_order: BlockTradeOrder,
     ) -> "Trade":
-        """Build a Trade leaf for a direct or offer (filled) trade. Constraints are zero."""
+        """Build a Trade for a direct or offer (filled) trade. Constraints are zero."""
         return cls(
             market=market,
             price=price,
@@ -97,7 +97,7 @@ class Trade:
         max_price: Decimal = decimal_zero,
         oracle_tolerance: Decimal = decimal_zero,
     ) -> "Trade":
-        """Build a Trade leaf for an offer-based parent block (constraints only, no fill)."""
+        """Build a Trade for an offer-based parent block (constraints only, no fill)."""
         return cls(
             market=market,
             min_size=min_size,
@@ -136,9 +136,9 @@ class BlockTradeOffer:
     field binds the offer cryptographically to a specific parent — an offer signed for
     parent A cannot be replayed against parent B.
 
-    Each Trade leaf should be built with the offerer's data on one side (maker by
-    convention, matching the server's merge logic) and the other side empty/zero.
-    Constraints in the leaf are zero — the offerer doesn't sign parent constraints.
+    Each Trade should be built with the offerer's data on one side (maker by convention,
+    matching the server's merge logic) and the other side empty/zero. Constraints are
+    zero — the offerer doesn't sign parent constraints.
     """
 
     def __init__(
@@ -162,9 +162,9 @@ def _chain_decimal(d: Decimal) -> str:
 
 
 def _empty_block_trade_order_message() -> dict:
-    """Zero-valued BlockTradeOrder leaf used when one side of a Trade is empty
-    (e.g. an offer where the offerer occupies maker side and taker side is empty
-    until merge). All fields encoded as "0" so starknet-py can parse as felts."""
+    """Zero-valued BlockTradeOrder used when one side of a Trade is empty (e.g. an offer
+    where the offerer occupies maker side and taker side is empty until merge). All fields
+    encoded as "0" so starknet-py can parse as felts."""
     return {
         "account": "0",
         "side": "0",
@@ -192,7 +192,7 @@ def _block_trade_order_message(order: BlockTradeOrder | None) -> dict:
     }
 
 
-def _trade_leaf_message(trade: Trade) -> dict:
+def _trade_message(trade: Trade) -> dict:
     return {
         "market": _felt_or_zero(trade.market),
         "price": _chain_decimal(trade.price),
@@ -228,8 +228,8 @@ def block_trade_from_response(response: BlockTradeDetailFullResponse, nonce: str
                     market=market,
                     price=Decimal(detail.price or "0"),
                     size=Decimal(detail.size or "0"),
-                    maker_order=_response_order_to_leaf_order(detail.maker_order),
-                    taker_order=_response_order_to_leaf_order(detail.taker_order),
+                    maker_order=_block_trade_order_from_response(detail.maker_order),
+                    taker_order=_block_trade_order_from_response(detail.taker_order),
                 )
             )
             continue
@@ -243,7 +243,7 @@ def block_trade_from_response(response: BlockTradeDetailFullResponse, nonce: str
                     max_size=Decimal(constraints.max_size or "0"),
                     min_price=Decimal(constraints.min_price or "0"),
                     max_price=Decimal(constraints.max_price or "0"),
-                    # oracle_tolerance is in the proto leaf but not yet exposed on
+                    # oracle_tolerance is in the proto Trade but not yet exposed on
                     # BlockTradeConstraints; default to 0 until the DTO adds it.
                     oracle_tolerance=Decimal(0),
                 )
@@ -252,8 +252,8 @@ def block_trade_from_response(response: BlockTradeDetailFullResponse, nonce: str
     return BlockTrade(nonce=nonce, expiration=expiration, trades=trades)
 
 
-def _response_order_to_leaf_order(response_order: BlockTradeOrderResponse) -> BlockTradeOrder:
-    """Convert a BlockTradeOrder DTO from a response into a leaf-level BlockTradeOrder."""
+def _block_trade_order_from_response(response_order: BlockTradeOrderResponse) -> BlockTradeOrder:
+    """Convert a response-side BlockTradeOrder DTO into the signing-side BlockTradeOrder."""
     return BlockTradeOrder(
         account=response_order.account or "",
         side=response_order.side.value,
@@ -323,7 +323,7 @@ def _build_block_typed_data(
         },
         "message": {
             **primary_values,
-            "trades": [_trade_leaf_message(t) for t in sorted_trades],
+            "trades": [_trade_message(t) for t in sorted_trades],
         },
     }
     return cast(TypedDataDict, message)

--- a/paradex_py/message/block_trades.py
+++ b/paradex_py/message/block_trades.py
@@ -301,10 +301,8 @@ def _build_block_typed_data(
 ) -> TypedDataDict:
     """Build SNIP-12 revision 1 (Poseidon) typed data for a block-trade-shaped payload.
 
-    Leaves are sorted alphabetically by market — the canonical ordering both client and
-    server agree on. The Go server iterates the request map in sorted order too; without
-    this, randomized Go map iteration would silently break multi-market flows because the
-    merkle root would only match by chance.
+    Trades are sorted alphabetically by market — the canonical ordering both client and
+    server agree on. Without this merkle root would not be deterministic.
     """
     sorted_trades = sorted(trades, key=lambda t: t.market)
     message = {

--- a/paradex_py/message/block_trades.py
+++ b/paradex_py/message/block_trades.py
@@ -3,96 +3,379 @@ from typing import cast
 
 from starknet_py.net.models.typed_data import TypedDataDict
 
-from paradex_py.common.order import Order
+from paradex_py.api.generated.responses import (
+    BlockTradeDetailFullResponse,
+)
+from paradex_py.api.generated.responses import BlockTradeOrder as BlockTradeOrderResponse
+from paradex_py.common.order import OrderSide, decimal_zero
+
+# BLOCK_TRADE_PAYLOAD_VERSION is the SNIP-12 BlockTrade schema version included in the
+# signed payload. Bump when the schema changes; client and server must agree.
+BLOCK_TRADE_PAYLOAD_VERSION = "2"
+
+
+class BlockTradeOrder:
+    """Order-side component of a Trade leaf. Distinct from the rev0 Order used for
+    standalone order signing: drops timestamp (replay protection lives at block level)
+    and market (lives at Trade level), but includes account explicitly since a Trade
+    leaf may carry orders from different participants.
+    """
+
+    def __init__(
+        self,
+        account: str = "",
+        side: str = "",
+        order_type: str = "",
+        size: Decimal = decimal_zero,
+        price: Decimal = decimal_zero,
+    ) -> None:
+        self.account = account
+        self.side = side
+        self.order_type = order_type
+        self.size = size
+        self.price = price
 
 
 class Trade:
+    """One leaf of the block-trade merkle tree.
+
+    A Trade carries either fill data (for direct/offer trades) or constraint data (for
+    offer-based parent blocks where only bounds are agreed at create time). Both variants
+    share the same schema: unused fields default to zero so the merkle root commits to
+    the absence of the other variant.
+    """
+
     def __init__(
         self,
-        price: Decimal,
-        size: Decimal,
-        maker_order: Order,
-        taker_order: Order,
+        market: str = "",
+        price: Decimal = decimal_zero,
+        size: Decimal = decimal_zero,
+        maker_order: BlockTradeOrder | None = None,
+        taker_order: BlockTradeOrder | None = None,
+        min_size: Decimal = decimal_zero,
+        max_size: Decimal = decimal_zero,
+        min_price: Decimal = decimal_zero,
+        max_price: Decimal = decimal_zero,
+        oracle_tolerance: Decimal = decimal_zero,
     ) -> None:
+        self.market = market
         self.price = price
         self.size = size
         self.maker_order = maker_order
         self.taker_order = taker_order
+        self.min_size = min_size
+        self.max_size = max_size
+        self.min_price = min_price
+        self.max_price = max_price
+        self.oracle_tolerance = oracle_tolerance
 
-    def chain_price(self) -> str:
-        return str(int(self.price.scaleb(8)))
+    @classmethod
+    def fill(
+        cls,
+        market: str,
+        price: Decimal,
+        size: Decimal,
+        maker_order: BlockTradeOrder,
+        taker_order: BlockTradeOrder,
+    ) -> "Trade":
+        """Build a Trade leaf for a direct or offer (filled) trade. Constraints are zero."""
+        return cls(
+            market=market,
+            price=price,
+            size=size,
+            maker_order=maker_order,
+            taker_order=taker_order,
+        )
 
-    def chain_size(self) -> str:
-        return str(int(self.size.scaleb(8)))
+    @classmethod
+    def constraint(
+        cls,
+        market: str,
+        min_size: Decimal = decimal_zero,
+        max_size: Decimal = decimal_zero,
+        min_price: Decimal = decimal_zero,
+        max_price: Decimal = decimal_zero,
+        oracle_tolerance: Decimal = decimal_zero,
+    ) -> "Trade":
+        """Build a Trade leaf for an offer-based parent block (constraints only, no fill)."""
+        return cls(
+            market=market,
+            min_size=min_size,
+            max_size=max_size,
+            min_price=min_price,
+            max_price=max_price,
+            oracle_tolerance=oracle_tolerance,
+        )
 
 
 class BlockTrade:
+    """Domain model for a block trade payload to be signed.
+
+    nonce and expiration are block-level fields included in the signed merkle struct hash;
+    every required signer of the same block produces a signature over the same messageHash.
+    """
+
     def __init__(
         self,
-        version: str,
+        nonce: str,
+        expiration: int,
         trades: list[Trade],
+        version: str = BLOCK_TRADE_PAYLOAD_VERSION,
     ) -> None:
         self.version = version
+        self.nonce = nonce
+        self.expiration = expiration
         self.trades = trades
 
 
-def build_block_trade_message(chain_id: int, block_trade: BlockTrade) -> TypedDataDict:
-    # Build trades array for the message
-    trades_message = []
-    for trade in block_trade.trades:
-        trade_data = {
-            "price": trade.chain_price(),
-            "size": trade.chain_size(),
-            "maker_order": {
-                "timestamp": str(trade.maker_order.signature_timestamp),
-                "market": trade.maker_order.market,
-                "side": trade.maker_order.order_side.chain_side(),
-                "orderType": trade.maker_order.order_type.value,
-                "size": trade.maker_order.chain_size(),
-                "price": trade.maker_order.chain_price(),
-            },
-            "taker_order": {
-                "timestamp": str(trade.taker_order.signature_timestamp),
-                "market": trade.taker_order.market,
-                "side": trade.taker_order.order_side.chain_side(),
-                "orderType": trade.taker_order.order_type.value,
-                "size": trade.taker_order.chain_size(),
-                "price": trade.taker_order.chain_price(),
-            },
-        }
-        trades_message.append(trade_data)
+class BlockTradeOffer:
+    """Domain model for a block trade offer payload to be signed by an offerer.
 
+    Distinct from BlockTrade: the offerer commits only to their own fills + the parent
+    block reference, NOT to the parent's constraints or expiration. The block_trade_id
+    field binds the offer cryptographically to a specific parent — an offer signed for
+    parent A cannot be replayed against parent B.
+
+    Each Trade leaf should be built with the offerer's data on one side (maker by
+    convention, matching the server's merge logic) and the other side empty/zero.
+    Constraints in the leaf are zero — the offerer doesn't sign parent constraints.
+    """
+
+    def __init__(
+        self,
+        nonce: str,
+        expiration: int,
+        block_trade_id: str,
+        trades: list[Trade],
+        version: str = BLOCK_TRADE_PAYLOAD_VERSION,
+    ) -> None:
+        self.version = version
+        self.nonce = nonce
+        self.expiration = expiration
+        self.block_trade_id = block_trade_id
+        self.trades = trades
+
+
+def _chain_decimal(d: Decimal) -> str:
+    """Scale a decimal to its on-chain integer representation (ParaclearDecimals = 8)."""
+    return str(int(Decimal(d).scaleb(8)))
+
+
+def _empty_block_trade_order_message() -> dict:
+    """Zero-valued BlockTradeOrder leaf used when one side of a Trade is empty
+    (e.g. an offer where the offerer occupies maker side and taker side is empty
+    until merge). All fields encoded as "0" so starknet-py can parse as felts."""
+    return {
+        "account": "0",
+        "side": "0",
+        "type": "0",
+        "size": "0",
+        "price": "0",
+    }
+
+
+def _felt_or_zero(s: str) -> str:
+    """Encode an empty string as "0" (felt zero) for starknet-py compatibility.
+    Empty strings fail felt parsing in the lib."""
+    return s if s else "0"
+
+
+def _block_trade_order_message(order: BlockTradeOrder | None) -> dict:
+    if order is None:
+        return _empty_block_trade_order_message()
+    return {
+        "account": _felt_or_zero(order.account),
+        "side": OrderSide(order.side).chain_side() if order.side else "0",
+        "type": _felt_or_zero(order.order_type),
+        "size": _chain_decimal(order.size),
+        "price": _chain_decimal(order.price),
+    }
+
+
+def _trade_leaf_message(trade: Trade) -> dict:
+    return {
+        "market": _felt_or_zero(trade.market),
+        "price": _chain_decimal(trade.price),
+        "size": _chain_decimal(trade.size),
+        "maker_order": _block_trade_order_message(trade.maker_order),
+        "taker_order": _block_trade_order_message(trade.taker_order),
+        "min_size": _chain_decimal(trade.min_size),
+        "max_size": _chain_decimal(trade.max_size),
+        "min_price": _chain_decimal(trade.min_price),
+        "max_price": _chain_decimal(trade.max_price),
+        "oracle_tolerance": _chain_decimal(trade.oracle_tolerance),
+    }
+
+
+def block_trade_from_response(response: BlockTradeDetailFullResponse, nonce: str, expiration: int) -> BlockTrade:
+    """Reconstruct the signing BlockTrade from a `BlockTradeDetailFullResponse`.
+
+    The reconstruction must produce the exact same trade leaves the server will recompute
+    when verifying — order, fill/constraint variant, and field values must all match.
+    The trades dict iteration order in the response is the canonical signing order
+    (the API serializes proto `repeated Trade` in insertion order, which Python dicts
+    preserve since 3.7).
+
+    Used by executors at execute time to sign the merkle root of an offer or direct
+    block they're accepting. The supplied `nonce` and `expiration` are the executor's
+    own — they do not have to match the create-time block-level nonce.
+    """
+    trades: list[Trade] = []
+    for market, detail in (response.trades or {}).items():
+        if detail.maker_order is not None and detail.taker_order is not None:
+            trades.append(
+                Trade.fill(
+                    market=market,
+                    price=Decimal(detail.price or "0"),
+                    size=Decimal(detail.size or "0"),
+                    maker_order=_response_order_to_leaf_order(detail.maker_order),
+                    taker_order=_response_order_to_leaf_order(detail.taker_order),
+                )
+            )
+            continue
+
+        constraints = detail.trade_constraints
+        if constraints is not None:
+            trades.append(
+                Trade.constraint(
+                    market=market,
+                    min_size=Decimal(constraints.min_size or "0"),
+                    max_size=Decimal(constraints.max_size or "0"),
+                    min_price=Decimal(constraints.min_price or "0"),
+                    max_price=Decimal(constraints.max_price or "0"),
+                    # oracle_tolerance is in the proto leaf but not yet exposed on
+                    # BlockTradeConstraints; default to 0 until the DTO adds it.
+                    oracle_tolerance=Decimal(0),
+                )
+            )
+
+    return BlockTrade(nonce=nonce, expiration=expiration, trades=trades)
+
+
+def _response_order_to_leaf_order(response_order: BlockTradeOrderResponse) -> BlockTradeOrder:
+    """Convert a BlockTradeOrder DTO from a response into a leaf-level BlockTradeOrder."""
+    return BlockTradeOrder(
+        account=response_order.account or "",
+        side=response_order.side.value,
+        order_type=response_order.type.value,
+        size=Decimal(response_order.size or "0"),
+        price=Decimal(response_order.price or "0"),
+    )
+
+
+_STARKNET_DOMAIN_TYPE = [
+    {"name": "name", "type": "shortstring"},
+    {"name": "version", "type": "shortstring"},
+    {"name": "chainId", "type": "shortstring"},
+    {"name": "revision", "type": "shortstring"},
+]
+
+_TRADE_TYPE = [
+    {"name": "market", "type": "shortstring"},
+    {"name": "price", "type": "felt"},
+    {"name": "size", "type": "felt"},
+    {"name": "maker_order", "type": "BlockTradeOrder"},
+    {"name": "taker_order", "type": "BlockTradeOrder"},
+    {"name": "min_size", "type": "felt"},
+    {"name": "max_size", "type": "felt"},
+    {"name": "min_price", "type": "felt"},
+    {"name": "max_price", "type": "felt"},
+    {"name": "oracle_tolerance", "type": "felt"},
+]
+
+_BLOCK_TRADE_ORDER_TYPE = [
+    {"name": "account", "type": "felt"},
+    {"name": "side", "type": "shortstring"},
+    {"name": "type", "type": "shortstring"},
+    {"name": "size", "type": "felt"},
+    {"name": "price", "type": "felt"},
+]
+
+
+def _build_block_typed_data(
+    chain_id: int,
+    primary_type: str,
+    primary_fields: list[dict],
+    primary_values: dict,
+    trades: list[Trade],
+) -> TypedDataDict:
+    """Build SNIP-12 revision 1 (Poseidon) typed data for a block-trade-shaped payload.
+
+    Leaves are sorted alphabetically by market — the canonical ordering both client and
+    server agree on. The Go server iterates the request map in sorted order too; without
+    this, randomized Go map iteration would silently break multi-market flows because the
+    merkle root would only match by chance.
+    """
+    sorted_trades = sorted(trades, key=lambda t: t.market)
     message = {
-        "domain": {"name": "Paradex", "chainId": hex(chain_id), "version": "1"},
-        "primaryType": "BlockTrade",
+        "domain": {
+            "name": "Paradex",
+            "chainId": hex(chain_id),
+            "version": "1",
+            "revision": "1",
+        },
+        "primaryType": primary_type,
         "types": {
-            "StarkNetDomain": [
-                {"name": "name", "type": "felt"},
-                {"name": "chainId", "type": "felt"},
-                {"name": "version", "type": "felt"},
-            ],
-            "BlockTrade": [
-                {"name": "version", "type": "shortstring"},
-                {"name": "trades", "type": "Trade*"},
-            ],
-            "Trade": [
-                {"name": "price", "type": "felt"},
-                {"name": "size", "type": "felt"},
-                {"name": "maker_order", "type": "Order"},
-                {"name": "taker_order", "type": "Order"},
-            ],
-            "Order": [
-                {"name": "timestamp", "type": "felt"},
-                {"name": "market", "type": "felt"},
-                {"name": "side", "type": "felt"},
-                {"name": "orderType", "type": "felt"},
-                {"name": "size", "type": "felt"},
-                {"name": "price", "type": "felt"},
-            ],
+            "StarknetDomain": _STARKNET_DOMAIN_TYPE,
+            primary_type: primary_fields,
+            "Trade": _TRADE_TYPE,
+            "BlockTradeOrder": _BLOCK_TRADE_ORDER_TYPE,
         },
         "message": {
-            "version": block_trade.version,
-            "trades": trades_message,
+            **primary_values,
+            "trades": [_trade_leaf_message(t) for t in sorted_trades],
         },
     }
     return cast(TypedDataDict, message)
+
+
+def build_block_trade_offer_message(chain_id: int, offer: BlockTradeOffer) -> TypedDataDict:
+    """Build the SNIP-12 typed data for a BlockTradeOffer.
+
+    Distinct primary type from BlockTrade — the resulting messageHash is cryptographically
+    domain-separated, so an offer signature cannot be replayed as a block-trade signature
+    even if the trade leaves match. The block_trade_id binds the offer to a specific parent.
+    """
+    return _build_block_typed_data(
+        chain_id,
+        primary_type="BlockTradeOffer",
+        primary_fields=[
+            {"name": "version", "type": "shortstring"},
+            {"name": "nonce", "type": "felt"},
+            {"name": "expiration", "type": "felt"},
+            {"name": "block_trade_id", "type": "felt"},
+            {"name": "trades", "type": "merkletree", "contains": "Trade"},
+        ],
+        primary_values={
+            "version": offer.version,
+            "nonce": offer.nonce,
+            "expiration": str(offer.expiration),
+            "block_trade_id": offer.block_trade_id,
+        },
+        trades=offer.trades,
+    )
+
+
+def build_block_trade_message(chain_id: int, block_trade: BlockTrade) -> TypedDataDict:
+    """Build the SNIP-12 typed data for a BlockTrade.
+
+    The trades slice is declared as `merkletree` in the schema, so the lib reduces the
+    leaves to a single felt (the merkle root) when computing the struct hash. A single
+    signature over this root commits to every trade leaf atomically.
+    """
+    return _build_block_typed_data(
+        chain_id,
+        primary_type="BlockTrade",
+        primary_fields=[
+            {"name": "version", "type": "shortstring"},
+            {"name": "nonce", "type": "felt"},
+            {"name": "expiration", "type": "felt"},
+            {"name": "trades", "type": "merkletree", "contains": "Trade"},
+        ],
+        primary_values={
+            "version": block_trade.version,
+            "nonce": block_trade.nonce,
+            "expiration": str(block_trade.expiration),
+        },
+        trades=block_trade.trades,
+    )

--- a/tests/integration/test_block_trades_workflow.py
+++ b/tests/integration/test_block_trades_workflow.py
@@ -77,7 +77,12 @@ from paradex_py.api.generated.responses import (
 from paradex_py.common.order import Order
 from paradex_py.common.order import OrderSide as CommonOrderSide
 from paradex_py.common.order import OrderType as CommonOrderType
-from paradex_py.message.block_trades import BlockTrade, Trade
+from paradex_py.message.block_trades import (
+    BlockTrade,
+    BlockTradeOffer,
+    BlockTradeOrder,
+    Trade,
+)
 
 # Set up logging with better console formatting
 logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)-8s | %(message)s", datefmt="%H:%M:%S")
@@ -170,123 +175,88 @@ def create_block_trade_order(
     )
 
 
-def sign_block_trade_request(client, request: BlockTradeRequest, signer_account: str) -> BlockTradeRequest:
-    """
-    Sign a BlockTradeRequest by creating the necessary BlockTrade object and adding signatures.
-    Supports multiple markets in the request.
-    """
-    # Create list of Trade objects from the request
-    trades = []
-
-    for market_symbol, trade_info in request.trades.items():
-        # Extract order details from the trade info
-        maker_order_data = trade_info.maker_order
-
-        # Create Order object for signing
-        maker_order = Order(
-            market=market_symbol,
-            order_type=CommonOrderType.Limit,
-            order_side=(
-                CommonOrderSide.Buy
-                if maker_order_data and maker_order_data.side == OrderSide.order_side_buy
-                else CommonOrderSide.Sell
-            ),
-            size=Decimal(str(trade_info.size)) if trade_info.size else Decimal("0"),
-            limit_price=Decimal(str(trade_info.price)) if trade_info.price else Decimal("0"),
-            client_id=maker_order_data.client_id if maker_order_data and maker_order_data.client_id else "",
-            signature_timestamp=(
-                maker_order_data.signature_timestamp if maker_order_data and maker_order_data.signature_timestamp else 0
-            ),
-            instruction="GTC",
-        )
-
-        # For simplicity, use maker order for both maker and taker
-        trade = Trade(
-            price=Decimal(str(trade_info.price)) if trade_info.price else Decimal("0"),
-            size=Decimal(str(trade_info.size)) if trade_info.size else Decimal("0"),
-            maker_order=maker_order,
-            taker_order=maker_order,
-        )
-        trades.append(trade)
-
-    # Create BlockTrade object
-    block_trade = BlockTrade(version="1.0", trades=trades)
-
-    # Sign the block trade
-    signature = client.account.sign_block_trade(block_trade)
-
-    # Create BlockTradeSignature
-    current_time = int(time.time() * 1000)
-    block_signature = BlockTradeSignature(
-        nonce=f"bt_sig_{current_time}",
-        signature_data=signature,
-        signature_expiration=current_time + (5 * 60 * 1000),  # 5 minutes
-        signature_timestamp=current_time,
-        signature_type=SignatureType.starknet,
-        signer_account=signer_account,
+def _leaf_order_from_dto(dto, account: str) -> BlockTradeOrder:
+    """Convert a BlockTradeOrder DTO from a request payload into a leaf BlockTradeOrder
+    (the rev2 signing-leaf type — no timestamp, no market, account inside)."""
+    side_value = ""
+    if dto and getattr(dto, "side", None) is not None:
+        side_value = dto.side.value if hasattr(dto.side, "value") else str(dto.side)
+        if side_value == OrderSide.order_side_buy.value or side_value == "BUY":
+            side_value = "BUY"
+        elif side_value == OrderSide.order_side_sell.value or side_value == "SELL":
+            side_value = "SELL"
+    type_value = ""
+    if dto and getattr(dto, "type", None) is not None:
+        type_value = dto.type.value if hasattr(dto.type, "value") else str(dto.type)
+    return BlockTradeOrder(
+        account=account,
+        side=side_value,
+        order_type=type_value or "LIMIT",
+        size=Decimal(str(dto.size)) if dto and dto.size else Decimal("0"),
+        price=Decimal(str(dto.price)) if dto and dto.price else Decimal("0"),
     )
 
-    # Add signature to request
-    request.signatures[signer_account] = block_signature
 
+def _build_trade_from_info(market_symbol: str, trade_info, initiator_addr: str, counterparty_addr: str) -> Trade:
+    """Build a signing-shape Trade leaf from a request BlockTradeInfo. Direct create:
+    both maker and taker DTOs are present. Offer-based create: only maker is set; taker
+    leaf is None (encoded as empty/zero leaf in the merkle)."""
+    maker_leaf = _leaf_order_from_dto(trade_info.maker_order, initiator_addr)
+    taker_leaf = _leaf_order_from_dto(trade_info.taker_order, counterparty_addr) if trade_info.taker_order else None
+    return Trade.fill(
+        market=market_symbol,
+        price=Decimal(str(trade_info.price)) if trade_info.price else Decimal("0"),
+        size=Decimal(str(trade_info.size)) if trade_info.size else Decimal("0"),
+        maker_order=maker_leaf,
+        taker_order=taker_leaf,
+    )
+
+
+def sign_block_trade_request(client, request: BlockTradeRequest, signer_account: str) -> BlockTradeRequest:
+    """Sign a BlockTradeRequest using the SDK's high-level helper.
+
+    The block-level nonce and expiration come from the request itself — every required signer
+    of the same block produces a signature over the same merkle messageHash.
+    """
+    counterparty = next((s for s in request.required_signers if s != signer_account), signer_account)
+    trades = [
+        _build_trade_from_info(market, info, signer_account, counterparty) for market, info in request.trades.items()
+    ]
+    block_trade = BlockTrade(
+        nonce=request.nonce,
+        expiration=request.block_expiration,
+        trades=trades,
+    )
+    request.signatures[signer_account] = client.account.build_block_trade_signature(block_trade)
     return request
 
 
 def sign_block_offer_request(client, request: BlockOfferRequest, signer_account: str) -> BlockOfferRequest:
+    """Sign a BlockOfferRequest using the rev2 BlockTradeOffer typed-data (distinct primary
+    type from BlockTrade). The offerer commits only to their own fills + the parent block
+    reference — the merkle leaves carry the offerer's side filled and the counter-side empty.
     """
-    Sign a BlockOfferRequest by creating the necessary BlockTrade object.
-    Supports multiple markets in the request.
-    """
-    # Create list of Trade objects from the request
+    parent_block_id = getattr(request, "parent_block_id", None) or getattr(request, "block_trade_id", "") or ""
+    expiration = int(time.time() * 1000) + (5 * 60 * 1000)
     trades = []
-
     for market_symbol, offer_info in request.trades.items():
-        # Extract order details from the offer info
-        offerer_order_data = offer_info.offerer_order
-
-        # Create Order object for signing
-        offerer_order = Order(
-            market=market_symbol,
-            order_type=CommonOrderType.Limit,
-            order_side=(
-                CommonOrderSide.Buy if offerer_order_data.side == OrderSide.order_side_buy else CommonOrderSide.Sell
-            ),
-            size=Decimal(str(offer_info.size)) if offer_info.size else Decimal("0"),
-            limit_price=Decimal(str(offer_info.price)) if offer_info.price else Decimal("0"),
-            client_id=offerer_order_data.client_id if offerer_order_data and offerer_order_data.client_id else "",
-            signature_timestamp=offerer_order_data.signature_timestamp,
-            instruction="GTC",
+        offerer_leaf = _leaf_order_from_dto(offer_info.offerer_order, signer_account)
+        trades.append(
+            Trade.fill(
+                market=market_symbol,
+                price=Decimal(offer_info.price),
+                size=Decimal(offer_info.size),
+                maker_order=offerer_leaf,
+                taker_order=None,
+            )
         )
-
-        # For offers, use the same order for both maker and taker
-        trade = Trade(
-            price=Decimal(offer_info.price),
-            size=Decimal(offer_info.size),
-            maker_order=offerer_order,
-            taker_order=offerer_order,
-        )
-        trades.append(trade)
-
-    # Create BlockTrade object
-    block_trade = BlockTrade(version="1.0", trades=trades)
-
-    # Sign the block offer
-    signature = client.account.sign_block_offer(block_trade)
-
-    # Create BlockTradeSignature
-    current_time = int(time.time() * 1000)
-    offer_signature = BlockTradeSignature(
-        nonce=f"offer_sig_{current_time}",
-        signature_data=signature,
-        signature_expiration=current_time + (5 * 60 * 1000),  # 5 minutes
-        signature_timestamp=current_time,
-        signature_type=SignatureType.starknet,
-        signer_account=signer_account,
+    offer = BlockTradeOffer(
+        nonce=request.nonce,
+        expiration=expiration,
+        block_trade_id=parent_block_id,
+        trades=trades,
     )
-
-    # Set signature on request
-    request.signature = offer_signature
-
+    request.signature = client.account.build_block_trade_offer_signature(offer)
     return request
 
 
@@ -1020,92 +990,23 @@ def test_execute_block_trade(client, block_trade_id, account_summaries, selected
         logger.warning("⚠️ Executor account lacks sufficient funds or info - execution may fail")
         return None
     current_time = int(time.time() * 1000)
-    expiration_time = current_time + (5 * 60 * 1000)  # 5 minutes
-    # For execution, we need to sign each selected offer individually
     signatures = {}
     selected_offers = selected_offers or []
     if selected_offers:
         try:
-            # Get the offers to extract their trade details for signing
-            offers_response = client.api_client.get_block_trade_offers(block_trade_id)
-            offers = offers_response.results or []
-            if not offers:
-                logger.warning("No offers found to execute")
-                return None
-
-            # Process each selected offer individually
+            offer_responses = []
             for offer_id in selected_offers:
-                # Find the specific offer details
-                offer = next((o for o in offers if o.get("id") == offer_id or o.get("block_id") == offer_id), None)
-                if not offer:
-                    logger.warning(f"Offer {offer_id} not found")
-                    continue
-
-                # Create individual trades for this specific offer
-                offer_trades = []
-
-                # Extract trade details from this offer
-                for market_symbol, offer_info in offer.get("trades", {}).items():
-                    offerer_order = offer_info.get("offerer_order", {})
-
-                    # Create Order objects for this offer's trade
-                    maker_order = Order(
-                        market=market_symbol,
-                        order_type=CommonOrderType.Limit,
-                        order_side=CommonOrderSide.Buy if offerer_order.get("side") == "BUY" else CommonOrderSide.Sell,
-                        size=Decimal(offer_info.get("size", "0")),
-                        limit_price=Decimal(offer_info.get("price", "0")),
-                        client_id=offerer_order.get("client_id", f"exec_{current_time}"),
-                        signature_timestamp=current_time,
-                        instruction="GTC",
-                    )
-
-                    taker_order = Order(
-                        market=market_symbol,
-                        order_type=CommonOrderType.Limit,
-                        order_side=CommonOrderSide.Sell if offerer_order.get("side") == "BUY" else CommonOrderSide.Buy,
-                        size=Decimal(offer_info.get("size", "0")),
-                        limit_price=Decimal(offer_info.get("price", "0")),
-                        client_id=f"taker_{current_time}",
-                        signature_timestamp=current_time,
-                        instruction="GTC",
-                    )
-
-                    # Create Trade object for this specific offer
-                    trade = Trade(
-                        price=Decimal(offer_info.get("price", "0")),
-                        size=Decimal(offer_info.get("size", "0")),
-                        maker_order=maker_order,
-                        taker_order=taker_order,
-                    )
-                    offer_trades.append(trade)
-
-                if offer_trades:
-                    # Create BlockTrade for this specific offer
-                    offer_block_trade = BlockTrade(version="1.0", trades=offer_trades)
-
-                    # Sign this specific offer as the initiator
-                    offer_signature_str = client.account.sign_block_trade(offer_block_trade)
-
-                    # Create signature for this offer
-                    offer_signature = BlockTradeSignature(
-                        nonce=f"exec_offer_{offer_id}_{current_time}",
-                        signature_data=offer_signature_str,
-                        signature_expiration=expiration_time,
-                        signature_timestamp=current_time,
-                        signature_type=SignatureType.starknet,
-                        signer_account=executor_account,
-                    )
-
-                    # Store signature with offer ID as key
-                    signatures[offer_id] = offer_signature
-                    log_info(f"Signed offer {offer_id} for execution")
-
+                try:
+                    offer_responses.append(client.api_client.get_block_trade(offer_id))
+                except Exception as e:
+                    logger.warning(f"Could not fetch offer {offer_id}: {e}")
+            if offer_responses:
+                signatures = client.account.build_executor_signatures_for_offers(offer_responses)
+                log_info(f"Signed {len(signatures)} offers for execution")
         except Exception as e:
             logger.error(f"Failed to create execution signatures: {e}")
             return None
 
-    # Create execute request
     request = BlockExecuteRequest(
         execution_nonce=f"execute_{current_time}", selected_offers=selected_offers, signatures=signatures
     )

--- a/tests/integration/test_block_trades_workflow.py
+++ b/tests/integration/test_block_trades_workflow.py
@@ -175,9 +175,12 @@ def create_block_trade_order(
     )
 
 
-def _leaf_order_from_dto(dto, account: str) -> BlockTradeOrder:
-    """Convert a BlockTradeOrder DTO from a request payload into a leaf BlockTradeOrder
-    (the rev2 signing-leaf type — no timestamp, no market, account inside)."""
+def _build_signing_block_trade_order(dto, account: str) -> BlockTradeOrder:
+    """Build a signing-side BlockTradeOrder from a request-payload BlockTradeOrder DTO.
+
+    Note: `BlockTradeOrder` here is the signing struct from `paradex_py.message.block_trades`
+    (the import at the top of this file shadows the request/response DTO of the same name).
+    """
     side_value = ""
     if dto and getattr(dto, "side", None) is not None:
         side_value = dto.side.value if hasattr(dto.side, "value") else str(dto.side)
@@ -198,17 +201,19 @@ def _leaf_order_from_dto(dto, account: str) -> BlockTradeOrder:
 
 
 def _build_trade_from_info(market_symbol: str, trade_info, initiator_addr: str, counterparty_addr: str) -> Trade:
-    """Build a signing-shape Trade leaf from a request BlockTradeInfo. Direct create:
-    both maker and taker DTOs are present. Offer-based create: only maker is set; taker
-    leaf is None (encoded as empty/zero leaf in the merkle)."""
-    maker_leaf = _leaf_order_from_dto(trade_info.maker_order, initiator_addr)
-    taker_leaf = _leaf_order_from_dto(trade_info.taker_order, counterparty_addr) if trade_info.taker_order else None
+    """Build a signing-shape Trade from a request BlockTradeInfo. Direct create: both maker
+    and taker orders are present. Offer-based create: only maker is set; taker is None
+    (encoded as empty/zero in the merkle)."""
+    maker_order = _build_signing_block_trade_order(trade_info.maker_order, initiator_addr)
+    taker_order = (
+        _build_signing_block_trade_order(trade_info.taker_order, counterparty_addr) if trade_info.taker_order else None
+    )
     return Trade.fill(
         market=market_symbol,
         price=Decimal(str(trade_info.price)) if trade_info.price else Decimal("0"),
         size=Decimal(str(trade_info.size)) if trade_info.size else Decimal("0"),
-        maker_order=maker_leaf,
-        taker_order=taker_leaf,
+        maker_order=maker_order,
+        taker_order=taker_order,
     )
 
 
@@ -232,21 +237,21 @@ def sign_block_trade_request(client, request: BlockTradeRequest, signer_account:
 
 
 def sign_block_offer_request(client, request: BlockOfferRequest, signer_account: str) -> BlockOfferRequest:
-    """Sign a BlockOfferRequest using the rev2 BlockTradeOffer typed-data (distinct primary
-    type from BlockTrade). The offerer commits only to their own fills + the parent block
-    reference — the merkle leaves carry the offerer's side filled and the counter-side empty.
+    """Sign a BlockOfferRequest using the BlockTradeOffer typed-data (distinct primary type
+    from BlockTrade). The offerer commits only to their own fills + the parent block
+    reference — each Trade carries the offerer's side filled and the counter-side empty.
     """
     parent_block_id = getattr(request, "parent_block_id", None) or getattr(request, "block_trade_id", "") or ""
     expiration = int(time.time() * 1000) + (5 * 60 * 1000)
     trades = []
     for market_symbol, offer_info in request.trades.items():
-        offerer_leaf = _leaf_order_from_dto(offer_info.offerer_order, signer_account)
+        offerer_order = _build_signing_block_trade_order(offer_info.offerer_order, signer_account)
         trades.append(
             Trade.fill(
                 market=market_symbol,
                 price=Decimal(offer_info.price),
                 size=Decimal(offer_info.size),
-                maker_order=offerer_leaf,
+                maker_order=offerer_order,
                 taker_order=None,
             )
         )

--- a/tests/integration/test_block_trades_workflow.py
+++ b/tests/integration/test_block_trades_workflow.py
@@ -80,8 +80,10 @@ from paradex_py.common.order import OrderType as CommonOrderType
 from paradex_py.message.block_trades import (
     BlockTrade,
     BlockTradeOffer,
-    BlockTradeOrder,
     Trade,
+)
+from paradex_py.message.block_trades import (
+    BlockTradeOrder as BlockTradeOrderSignPayload,
 )
 
 # Set up logging with better console formatting
@@ -175,7 +177,7 @@ def create_block_trade_order(
     )
 
 
-def _build_signing_block_trade_order(dto, account: str) -> BlockTradeOrder:
+def _build_signing_block_trade_order(dto, account: str) -> BlockTradeOrderSignPayload:
     """Build a signing-side BlockTradeOrder from a request-payload BlockTradeOrder DTO.
 
     Note: `BlockTradeOrder` here is the signing struct from `paradex_py.message.block_trades`
@@ -191,7 +193,7 @@ def _build_signing_block_trade_order(dto, account: str) -> BlockTradeOrder:
     type_value = ""
     if dto and getattr(dto, "type", None) is not None:
         type_value = dto.type.value if hasattr(dto.type, "value") else str(dto.type)
-    return BlockTradeOrder(
+    return BlockTradeOrderSignPayload(
         account=account,
         side=side_value,
         order_type=type_value or "LIMIT",

--- a/tests/message/test_block_trades.py
+++ b/tests/message/test_block_trades.py
@@ -13,22 +13,22 @@ from paradex_py.message.block_trades import (
 
 
 def _eth_perp_orders():
-    """Two BlockTradeOrders on ETH-USD-PERP — matched maker/taker."""
-    maker = BlockTradeOrder(
+    """Two matched BlockTradeOrders on ETH-USD-PERP — maker (BUY) and taker (SELL)."""
+    maker_order = BlockTradeOrder(
         account="0xMAKER",
         side="BUY",
         order_type="LIMIT",
         size=Decimal("0.1"),
         price=Decimal("1500"),
     )
-    taker = BlockTradeOrder(
+    taker_order = BlockTradeOrder(
         account="0xTAKER",
         side="SELL",
         order_type="LIMIT",
         size=Decimal("0.1"),
         price=Decimal("1500"),
     )
-    return maker, taker
+    return maker_order, taker_order
 
 
 def test_block_trade_order_class():
@@ -57,20 +57,20 @@ def test_block_trade_order_defaults():
 
 
 def test_trade_fill_helper():
-    maker, taker = _eth_perp_orders()
+    maker_order, taker_order = _eth_perp_orders()
     trade = Trade.fill(
         market="ETH-USD-PERP",
         price=Decimal("1500.50"),
         size=Decimal("0.1"),
-        maker_order=maker,
-        taker_order=taker,
+        maker_order=maker_order,
+        taker_order=taker_order,
     )
 
     assert trade.market == "ETH-USD-PERP"
     assert trade.price == Decimal("1500.50")
     assert trade.size == Decimal("0.1")
-    assert trade.maker_order is maker
-    assert trade.taker_order is taker
+    assert trade.maker_order is maker_order
+    assert trade.taker_order is taker_order
     assert trade.min_size == Decimal(0)
     assert trade.max_size == Decimal(0)
 
@@ -97,14 +97,14 @@ def test_trade_constraint_helper():
 
 
 def test_block_trade_class():
-    maker, taker = _eth_perp_orders()
+    maker_order, taker_order = _eth_perp_orders()
     trades = [
         Trade.fill(
             market="ETH-USD-PERP",
             price=Decimal("1500.50"),
             size=Decimal("0.1"),
-            maker_order=maker,
-            taker_order=taker,
+            maker_order=maker_order,
+            taker_order=taker_order,
         ),
     ]
 
@@ -116,8 +116,8 @@ def test_block_trade_class():
 
 
 def test_block_trade_offer_class():
-    maker, _ = _eth_perp_orders()
-    trades = [Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, None)]
+    maker_order, _ = _eth_perp_orders()
+    trades = [Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker_order, None)]
     offer = BlockTradeOffer(
         nonce="off1",
         expiration=1700000000000,
@@ -131,13 +131,13 @@ def test_block_trade_offer_class():
 
 def test_build_block_trade_message_fill():
     """Single-leg fill Trade — verify the SNIP-12 rev1 typed-data structure end-to-end."""
-    maker, taker = _eth_perp_orders()
+    maker_order, taker_order = _eth_perp_orders()
     trade = Trade.fill(
         market="ETH-USD-PERP",
         price=Decimal("1500.50"),
         size=Decimal("0.1"),
-        maker_order=maker,
-        taker_order=taker,
+        maker_order=maker_order,
+        taker_order=taker_order,
     )
     block_trade = BlockTrade(nonce="42", expiration=1700000000000, trades=[trade])
     message = build_block_trade_message(1, block_trade)
@@ -256,12 +256,12 @@ def test_build_block_trade_message_constraint_only():
 
 def test_build_block_trade_message_offer_based_one_side():
     """Offer-based create with one side filled (initiator) and the other empty (offer fills later)."""
-    maker, _ = _eth_perp_orders()
+    maker_order, _ = _eth_perp_orders()
     trade = Trade.fill(
         market="ETH-USD-PERP",
         price=Decimal("1500"),
         size=Decimal("0.1"),
-        maker_order=maker,
+        maker_order=maker_order,
         taker_order=None,
     )
     block_trade = BlockTrade(nonce="n", expiration=1700000000000, trades=[trade])
@@ -281,9 +281,9 @@ def test_build_block_trade_message_offer_based_one_side():
 def test_build_block_trade_message_sorts_by_market():
     """Trades are canonically sorted by market (alphabetical) regardless of input order.
     Without this the merkle root diverges from the server, which sorts independently."""
-    maker, taker = _eth_perp_orders()
-    eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, taker)
-    btc = Trade.fill("BTC-USD-PERP", Decimal("45000"), Decimal("0.01"), maker, taker)
+    maker_order, taker_order = _eth_perp_orders()
+    eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker_order, taker_order)
+    btc = Trade.fill("BTC-USD-PERP", Decimal("45000"), Decimal("0.01"), maker_order, taker_order)
 
     bt_eth_first = BlockTrade(nonce="n", expiration=1700000000000, trades=[eth, btc])
     bt_btc_first = BlockTrade(nonce="n", expiration=1700000000000, trades=[btc, eth])
@@ -299,9 +299,9 @@ def test_build_block_trade_message_sorts_by_market():
 
 
 def test_build_block_trade_offer_message_sorts_by_market():
-    maker, _ = _eth_perp_orders()
-    eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, None)
-    btc = Trade.fill("BTC-USD-PERP", Decimal("45000"), Decimal("0.01"), maker, None)
+    maker_order, _ = _eth_perp_orders()
+    eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker_order, None)
+    btc = Trade.fill("BTC-USD-PERP", Decimal("45000"), Decimal("0.01"), maker_order, None)
 
     offer_eth_first = BlockTradeOffer(nonce="o", expiration=1700000000000, block_trade_id="P", trades=[eth, btc])
     offer_btc_first = BlockTradeOffer(nonce="o", expiration=1700000000000, block_trade_id="P", trades=[btc, eth])
@@ -315,8 +315,8 @@ def test_build_block_trade_offer_message_sorts_by_market():
 
 def test_build_block_trade_offer_message_schema():
     """Offer typed-data has primaryType BlockTradeOffer and binds block_trade_id."""
-    maker, _ = _eth_perp_orders()
-    trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, None)
+    maker_order, _ = _eth_perp_orders()
+    trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker_order, None)
     offer = BlockTradeOffer(
         nonce="o1",
         expiration=1700000000000,
@@ -342,8 +342,8 @@ def test_block_trade_offer_distinct_primary_type():
     """BlockTrade and BlockTradeOffer are cryptographically domain-separated by primaryType.
     Even with identical Trades, the typed-data messages differ — so signatures cannot be
     replayed across the two flows."""
-    maker, taker = _eth_perp_orders()
-    trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, taker)
+    maker_order, taker_order = _eth_perp_orders()
+    trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker_order, taker_order)
 
     bt = BlockTrade(nonce="x", expiration=1700000000000, trades=[trade])
     offer = BlockTradeOffer(nonce="x", expiration=1700000000000, block_trade_id="P", trades=[trade])

--- a/tests/message/test_block_trades.py
+++ b/tests/message/test_block_trades.py
@@ -13,7 +13,7 @@ from paradex_py.message.block_trades import (
 
 
 def _eth_perp_orders():
-    """Two BlockTradeOrder leaves on ETH-USD-PERP — matched maker/taker."""
+    """Two BlockTradeOrders on ETH-USD-PERP — matched maker/taker."""
     maker = BlockTradeOrder(
         account="0xMAKER",
         side="BUY",
@@ -32,28 +32,28 @@ def _eth_perp_orders():
 
 
 def test_block_trade_order_class():
-    leaf = BlockTradeOrder(
+    order = BlockTradeOrder(
         account="0xABC",
         side="BUY",
         order_type="LIMIT",
         size=Decimal("0.5"),
         price=Decimal("100"),
     )
-    assert leaf.account == "0xABC"
-    assert leaf.side == "BUY"
-    assert leaf.order_type == "LIMIT"
-    assert leaf.size == Decimal("0.5")
-    assert leaf.price == Decimal("100")
+    assert order.account == "0xABC"
+    assert order.side == "BUY"
+    assert order.order_type == "LIMIT"
+    assert order.size == Decimal("0.5")
+    assert order.price == Decimal("100")
 
 
 def test_block_trade_order_defaults():
-    """Empty leaf — used when one side of a Trade is unfilled (e.g. offer-based parent)."""
-    leaf = BlockTradeOrder()
-    assert leaf.account == ""
-    assert leaf.side == ""
-    assert leaf.order_type == ""
-    assert leaf.size == Decimal(0)
-    assert leaf.price == Decimal(0)
+    """Empty BlockTradeOrder — used when one side of a Trade is unfilled (e.g. offer-based parent)."""
+    order = BlockTradeOrder()
+    assert order.account == ""
+    assert order.side == ""
+    assert order.order_type == ""
+    assert order.size == Decimal(0)
+    assert order.price == Decimal(0)
 
 
 def test_trade_fill_helper():
@@ -130,7 +130,7 @@ def test_block_trade_offer_class():
 
 
 def test_build_block_trade_message_fill():
-    """Single-leg fill leaf — verify the SNIP-12 rev1 typed-data structure end-to-end."""
+    """Single-leg fill Trade — verify the SNIP-12 rev1 typed-data structure end-to-end."""
     maker, taker = _eth_perp_orders()
     trade = Trade.fill(
         market="ETH-USD-PERP",
@@ -220,7 +220,7 @@ def test_build_block_trade_message_fill():
 
 
 def test_build_block_trade_message_constraint_only():
-    """Offer-based parent block: leaves carry constraints, fill fields zero."""
+    """Offer-based parent block: Trades carry constraints, fill fields zero."""
     trade = Trade.constraint(
         market="BTC-USD-PERP",
         min_size=Decimal("0.05"),
@@ -232,20 +232,20 @@ def test_build_block_trade_message_constraint_only():
     block_trade = BlockTrade(nonce="99", expiration=1700000000000, trades=[trade])
     message = build_block_trade_message(1, block_trade)
 
-    leaf = message["message"]["trades"][0]
+    trade_msg = message["message"]["trades"][0]
     # Constraint fields populated
-    assert leaf["market"] == "BTC-USD-PERP"
-    assert leaf["min_size"] == "5000000"  # 0.05 * 1e8
-    assert leaf["max_size"] == "100000000"  # 1.0 * 1e8
-    assert leaf["min_price"] == "2900000000000"
-    assert leaf["max_price"] == "3100000000000"
-    assert leaf["oracle_tolerance"] == "2000000"
+    assert trade_msg["market"] == "BTC-USD-PERP"
+    assert trade_msg["min_size"] == "5000000"  # 0.05 * 1e8
+    assert trade_msg["max_size"] == "100000000"  # 1.0 * 1e8
+    assert trade_msg["min_price"] == "2900000000000"
+    assert trade_msg["max_price"] == "3100000000000"
+    assert trade_msg["oracle_tolerance"] == "2000000"
     # Fill fields zero
-    assert leaf["price"] == "0"
-    assert leaf["size"] == "0"
-    # Empty BlockTradeOrder leaves on both sides — encoded with all "0"
+    assert trade_msg["price"] == "0"
+    assert trade_msg["size"] == "0"
+    # Empty BlockTradeOrders on both sides — encoded with all "0"
     for side_key in ("maker_order", "taker_order"):
-        assert leaf[side_key] == {
+        assert trade_msg[side_key] == {
             "account": "0",
             "side": "0",
             "type": "0",
@@ -267,9 +267,9 @@ def test_build_block_trade_message_offer_based_one_side():
     block_trade = BlockTrade(nonce="n", expiration=1700000000000, trades=[trade])
     message = build_block_trade_message(1, block_trade)
 
-    leaf = message["message"]["trades"][0]
-    assert leaf["maker_order"]["account"] == "0xMAKER"
-    assert leaf["taker_order"] == {
+    trade_msg = message["message"]["trades"][0]
+    assert trade_msg["maker_order"]["account"] == "0xMAKER"
+    assert trade_msg["taker_order"] == {
         "account": "0",
         "side": "0",
         "type": "0",
@@ -279,7 +279,7 @@ def test_build_block_trade_message_offer_based_one_side():
 
 
 def test_build_block_trade_message_sorts_by_market():
-    """Leaves are canonically sorted by market (alphabetical) regardless of input order.
+    """Trades are canonically sorted by market (alphabetical) regardless of input order.
     Without this the merkle root diverges from the server, which sorts independently."""
     maker, taker = _eth_perp_orders()
     eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, taker)
@@ -340,8 +340,8 @@ def test_build_block_trade_offer_message_schema():
 
 def test_block_trade_offer_distinct_primary_type():
     """BlockTrade and BlockTradeOffer are cryptographically domain-separated by primaryType.
-    Even with identical trade leaves, the typed-data messages differ — so signatures
-    cannot be replayed across the two flows."""
+    Even with identical Trades, the typed-data messages differ — so signatures cannot be
+    replayed across the two flows."""
     maker, taker = _eth_perp_orders()
     trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, taker)
 
@@ -357,7 +357,7 @@ def test_block_trade_offer_distinct_primary_type():
 
 
 class _FakeOrder:
-    """Minimal stand-in for a server-returned BlockTradeOrder DTO (Pydantic-like)."""
+    """Minimal stand-in for a server-returned BlockTradeOrder"""
 
     def __init__(self, account, side_value, type_value, size, price):
         self.account = account
@@ -398,17 +398,17 @@ def test_block_trade_from_response_fill():
     assert bt.nonce == "executor_nonce"
     assert bt.expiration == 1700000000000
     assert len(bt.trades) == 1
-    leaf = bt.trades[0]
-    assert leaf.market == "ETH-USD-PERP"
-    assert leaf.price == Decimal("1500")
-    assert leaf.size == Decimal("0.1")
-    assert leaf.maker_order.account == "0xMAKER"
-    assert leaf.maker_order.side == "SELL"
-    assert leaf.taker_order.account == "0xTAKER"
-    assert leaf.taker_order.side == "BUY"
-    # Constraints zero (fill leaf)
-    assert leaf.min_size == Decimal(0)
-    assert leaf.max_size == Decimal(0)
+    trade = bt.trades[0]
+    assert trade.market == "ETH-USD-PERP"
+    assert trade.price == Decimal("1500")
+    assert trade.size == Decimal("0.1")
+    assert trade.maker_order.account == "0xMAKER"
+    assert trade.maker_order.side == "SELL"
+    assert trade.taker_order.account == "0xTAKER"
+    assert trade.taker_order.side == "BUY"
+    # Constraints zero (fill Trade)
+    assert trade.min_size == Decimal(0)
+    assert trade.max_size == Decimal(0)
 
 
 class _FakeConstraints:
@@ -419,7 +419,7 @@ class _FakeConstraints:
 
 def test_block_trade_message_hash_pinned():
     """Pin the messageHash for a fixed BlockTrade input. Tied to the schema, encoding,
-    leaf-sort, and domain definitions — any change to any of those flips this hash, so
+    trade sort, and domain definitions — any change to any of those flips this hash, so
     an equivalent verifier (e.g. a server) producing the same hash for the same inputs
     confirms the two implementations stay aligned."""
     from starknet_py.utils.typed_data import TypedData
@@ -455,7 +455,7 @@ def test_block_trade_offer_message_hash_pinned():
     maker_address = "0x1111"
     maker_btc = BlockTradeOrder(maker_address, "SELL", "LIMIT", Decimal("0.1"), Decimal("73000"))
     maker_eth = BlockTradeOrder(maker_address, "SELL", "LIMIT", Decimal("1"), Decimal("3000"))
-    # Offerer occupies maker side only; taker side is None (empty leaf, encoded as zero).
+    # Offerer occupies maker side only; taker side is None (encoded as zero BlockTradeOrder).
     offer = BlockTradeOffer(
         nonce="offer_nonce_1",
         expiration=1700000300000,
@@ -480,9 +480,9 @@ def test_block_trade_from_response_constraint_only():
 
     bt = block_trade_from_response(response, nonce="n", expiration=1700000000000)
     assert len(bt.trades) == 1
-    leaf = bt.trades[0]
-    assert leaf.market == "BTC-USD-PERP"
-    assert leaf.min_size == Decimal("0.05")
-    assert leaf.max_price == Decimal("31000")
-    assert leaf.maker_order is None
-    assert leaf.taker_order is None
+    trade = bt.trades[0]
+    assert trade.market == "BTC-USD-PERP"
+    assert trade.min_size == Decimal("0.05")
+    assert trade.max_price == Decimal("31000")
+    assert trade.maker_order is None
+    assert trade.taker_order is None

--- a/tests/message/test_block_trades.py
+++ b/tests/message/test_block_trades.py
@@ -1,178 +1,216 @@
 from decimal import Decimal
 
-from paradex_py.common.order import Order, OrderSide, OrderType
-from paradex_py.message.block_trades import BlockTrade, Trade, build_block_trade_message
+from paradex_py.message.block_trades import (
+    BLOCK_TRADE_PAYLOAD_VERSION,
+    BlockTrade,
+    BlockTradeOffer,
+    BlockTradeOrder,
+    Trade,
+    block_trade_from_response,
+    build_block_trade_message,
+    build_block_trade_offer_message,
+)
 
 
-def test_trade_class():
-    # Create test orders
-    maker_order = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Buy,
+def _eth_perp_orders():
+    """Two BlockTradeOrder leaves on ETH-USD-PERP — matched maker/taker."""
+    maker = BlockTradeOrder(
+        account="0xMAKER",
+        side="BUY",
+        order_type="LIMIT",
         size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000000,
+        price=Decimal("1500"),
     )
-
-    taker_order = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Sell,
+    taker = BlockTradeOrder(
+        account="0xTAKER",
+        side="SELL",
+        order_type="LIMIT",
         size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000001,
+        price=Decimal("1500"),
     )
+    return maker, taker
 
-    # Create trade
-    trade = Trade(
+
+def test_block_trade_order_class():
+    leaf = BlockTradeOrder(
+        account="0xABC",
+        side="BUY",
+        order_type="LIMIT",
+        size=Decimal("0.5"),
+        price=Decimal("100"),
+    )
+    assert leaf.account == "0xABC"
+    assert leaf.side == "BUY"
+    assert leaf.order_type == "LIMIT"
+    assert leaf.size == Decimal("0.5")
+    assert leaf.price == Decimal("100")
+
+
+def test_block_trade_order_defaults():
+    """Empty leaf — used when one side of a Trade is unfilled (e.g. offer-based parent)."""
+    leaf = BlockTradeOrder()
+    assert leaf.account == ""
+    assert leaf.side == ""
+    assert leaf.order_type == ""
+    assert leaf.size == Decimal(0)
+    assert leaf.price == Decimal(0)
+
+
+def test_trade_fill_helper():
+    maker, taker = _eth_perp_orders()
+    trade = Trade.fill(
+        market="ETH-USD-PERP",
         price=Decimal("1500.50"),
         size=Decimal("0.1"),
-        maker_order=maker_order,
-        taker_order=taker_order,
+        maker_order=maker,
+        taker_order=taker,
     )
 
-    # Test properties
+    assert trade.market == "ETH-USD-PERP"
     assert trade.price == Decimal("1500.50")
     assert trade.size == Decimal("0.1")
-    assert trade.maker_order == maker_order
-    assert trade.taker_order == taker_order
+    assert trade.maker_order is maker
+    assert trade.taker_order is taker
+    assert trade.min_size == Decimal(0)
+    assert trade.max_size == Decimal(0)
 
-    # Test chain formatting
-    assert trade.chain_price() == "150050000000"  # 1500.50 * 10^8
-    assert trade.chain_size() == "10000000"  # 0.1 * 10^8
+
+def test_trade_constraint_helper():
+    trade = Trade.constraint(
+        market="ETH-USD-PERP",
+        min_size=Decimal("0.05"),
+        max_size=Decimal("1.0"),
+        min_price=Decimal("1400"),
+        max_price=Decimal("1600"),
+        oracle_tolerance=Decimal("0.02"),
+    )
+
+    assert trade.market == "ETH-USD-PERP"
+    assert trade.price == Decimal(0)
+    assert trade.size == Decimal(0)
+    assert trade.maker_order is None
+    assert trade.taker_order is None
+    assert trade.min_size == Decimal("0.05")
+    assert trade.max_size == Decimal("1.0")
+    assert trade.max_price == Decimal("1600")
+    assert trade.oracle_tolerance == Decimal("0.02")
 
 
 def test_block_trade_class():
-    # Create test orders
-    maker_order = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Buy,
-        size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000000,
-    )
-
-    taker_order = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Sell,
-        size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000001,
-    )
-
-    # Create trades
+    maker, taker = _eth_perp_orders()
     trades = [
-        Trade(
+        Trade.fill(
+            market="ETH-USD-PERP",
             price=Decimal("1500.50"),
             size=Decimal("0.1"),
-            maker_order=maker_order,
-            taker_order=taker_order,
-        ),
-        Trade(
-            price=Decimal("1501.00"),
-            size=Decimal("0.05"),
-            maker_order=maker_order,
-            taker_order=taker_order,
+            maker_order=maker,
+            taker_order=taker,
         ),
     ]
 
-    # Create block trade
-    block_trade = BlockTrade(version="1.0", trades=trades)
-
-    # Test properties
-    assert block_trade.version == "1.0"
-    assert len(block_trade.trades) == 2
-    assert block_trade.trades[0].price == Decimal("1500.50")
-    assert block_trade.trades[1].price == Decimal("1501.00")
+    block_trade = BlockTrade(nonce="n1", expiration=1700000000000, trades=trades)
+    assert block_trade.version == BLOCK_TRADE_PAYLOAD_VERSION
+    assert block_trade.nonce == "n1"
+    assert block_trade.expiration == 1700000000000
+    assert len(block_trade.trades) == 1
 
 
-def test_build_block_trade_message():
-    # Create test orders
-    maker_order = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Buy,
-        size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000000,
+def test_block_trade_offer_class():
+    maker, _ = _eth_perp_orders()
+    trades = [Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, None)]
+    offer = BlockTradeOffer(
+        nonce="off1",
+        expiration=1700000000000,
+        block_trade_id="parent_id_123",
+        trades=trades,
     )
+    assert offer.version == BLOCK_TRADE_PAYLOAD_VERSION
+    assert offer.block_trade_id == "parent_id_123"
+    assert len(offer.trades) == 1
 
-    taker_order = Order(
+
+def test_build_block_trade_message_fill():
+    """Single-leg fill leaf — verify the SNIP-12 rev1 typed-data structure end-to-end."""
+    maker, taker = _eth_perp_orders()
+    trade = Trade.fill(
         market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Sell,
-        size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000001,
-    )
-
-    # Create trade
-    trade = Trade(
         price=Decimal("1500.50"),
         size=Decimal("0.1"),
-        maker_order=maker_order,
-        taker_order=taker_order,
+        maker_order=maker,
+        taker_order=taker,
     )
-
-    # Create block trade
-    block_trade = BlockTrade(version="1.0", trades=[trade])
-
-    # Test message building
+    block_trade = BlockTrade(nonce="42", expiration=1700000000000, trades=[trade])
     message = build_block_trade_message(1, block_trade)
 
     expected = {
-        "domain": {"name": "Paradex", "chainId": "0x1", "version": "1"},
+        "domain": {
+            "name": "Paradex",
+            "chainId": "0x1",
+            "version": "1",
+            "revision": "1",
+        },
         "primaryType": "BlockTrade",
         "types": {
-            "StarkNetDomain": [
-                {"name": "name", "type": "felt"},
-                {"name": "chainId", "type": "felt"},
-                {"name": "version", "type": "felt"},
+            "StarknetDomain": [
+                {"name": "name", "type": "shortstring"},
+                {"name": "version", "type": "shortstring"},
+                {"name": "chainId", "type": "shortstring"},
+                {"name": "revision", "type": "shortstring"},
             ],
             "BlockTrade": [
                 {"name": "version", "type": "shortstring"},
-                {"name": "trades", "type": "Trade*"},
+                {"name": "nonce", "type": "felt"},
+                {"name": "expiration", "type": "felt"},
+                {"name": "trades", "type": "merkletree", "contains": "Trade"},
             ],
             "Trade": [
+                {"name": "market", "type": "shortstring"},
                 {"name": "price", "type": "felt"},
                 {"name": "size", "type": "felt"},
-                {"name": "maker_order", "type": "Order"},
-                {"name": "taker_order", "type": "Order"},
+                {"name": "maker_order", "type": "BlockTradeOrder"},
+                {"name": "taker_order", "type": "BlockTradeOrder"},
+                {"name": "min_size", "type": "felt"},
+                {"name": "max_size", "type": "felt"},
+                {"name": "min_price", "type": "felt"},
+                {"name": "max_price", "type": "felt"},
+                {"name": "oracle_tolerance", "type": "felt"},
             ],
-            "Order": [
-                {"name": "timestamp", "type": "felt"},
-                {"name": "market", "type": "felt"},
-                {"name": "side", "type": "felt"},
-                {"name": "orderType", "type": "felt"},
+            "BlockTradeOrder": [
+                {"name": "account", "type": "felt"},
+                {"name": "side", "type": "shortstring"},
+                {"name": "type", "type": "shortstring"},
                 {"name": "size", "type": "felt"},
                 {"name": "price", "type": "felt"},
             ],
         },
         "message": {
-            "version": "1.0",
+            "version": "2",
+            "nonce": "42",
+            "expiration": "1700000000000",
             "trades": [
                 {
-                    "price": "150050000000",  # 1500.50 * 10^8
-                    "size": "10000000",  # 0.1 * 10^8
+                    "market": "ETH-USD-PERP",
+                    "price": "150050000000",
+                    "size": "10000000",
                     "maker_order": {
-                        "timestamp": "1634736000000",
-                        "market": "ETH-USD-PERP",
-                        "side": "1",  # Buy
-                        "orderType": "LIMIT",
-                        "size": "10000000",  # 0.1 * 10^8
-                        "price": "150000000000",  # 1500 * 10^8
+                        "account": "0xMAKER",
+                        "side": "1",  # BUY → "1"
+                        "type": "LIMIT",
+                        "size": "10000000",
+                        "price": "150000000000",
                     },
                     "taker_order": {
-                        "timestamp": "1634736000001",
-                        "market": "ETH-USD-PERP",
-                        "side": "2",  # Sell
-                        "orderType": "LIMIT",
-                        "size": "10000000",  # 0.1 * 10^8
-                        "price": "150000000000",  # 1500 * 10^8
+                        "account": "0xTAKER",
+                        "side": "2",  # SELL → "2"
+                        "type": "LIMIT",
+                        "size": "10000000",
+                        "price": "150000000000",
                     },
+                    "min_size": "0",
+                    "max_size": "0",
+                    "min_price": "0",
+                    "max_price": "0",
+                    "oracle_tolerance": "0",
                 }
             ],
         },
@@ -181,86 +219,270 @@ def test_build_block_trade_message():
     assert message == expected
 
 
-def test_build_block_trade_message_multiple_trades():
-    # Create test orders
-    maker_order1 = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Buy,
-        size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000000,
-    )
-
-    taker_order1 = Order(
-        market="ETH-USD-PERP",
-        order_type=OrderType.Limit,
-        order_side=OrderSide.Sell,
-        size=Decimal("0.1"),
-        limit_price=Decimal("1500"),
-        signature_timestamp=1634736000001,
-    )
-
-    maker_order2 = Order(
+def test_build_block_trade_message_constraint_only():
+    """Offer-based parent block: leaves carry constraints, fill fields zero."""
+    trade = Trade.constraint(
         market="BTC-USD-PERP",
-        order_type=OrderType.Market,
-        order_side=OrderSide.Sell,
-        size=Decimal("0.01"),
-        limit_price=Decimal("0"),  # Market order
-        signature_timestamp=1634736000002,
+        min_size=Decimal("0.05"),
+        max_size=Decimal("1.0"),
+        min_price=Decimal("29000"),
+        max_price=Decimal("31000"),
+        oracle_tolerance=Decimal("0.02"),
     )
+    block_trade = BlockTrade(nonce="99", expiration=1700000000000, trades=[trade])
+    message = build_block_trade_message(1, block_trade)
 
-    taker_order2 = Order(
-        market="BTC-USD-PERP",
-        order_type=OrderType.Market,
-        order_side=OrderSide.Buy,
-        size=Decimal("0.01"),
-        limit_price=Decimal("0"),  # Market order
-        signature_timestamp=1634736000003,
+    leaf = message["message"]["trades"][0]
+    # Constraint fields populated
+    assert leaf["market"] == "BTC-USD-PERP"
+    assert leaf["min_size"] == "5000000"  # 0.05 * 1e8
+    assert leaf["max_size"] == "100000000"  # 1.0 * 1e8
+    assert leaf["min_price"] == "2900000000000"
+    assert leaf["max_price"] == "3100000000000"
+    assert leaf["oracle_tolerance"] == "2000000"
+    # Fill fields zero
+    assert leaf["price"] == "0"
+    assert leaf["size"] == "0"
+    # Empty BlockTradeOrder leaves on both sides — encoded with all "0"
+    for side_key in ("maker_order", "taker_order"):
+        assert leaf[side_key] == {
+            "account": "0",
+            "side": "0",
+            "type": "0",
+            "size": "0",
+            "price": "0",
+        }
+
+
+def test_build_block_trade_message_offer_based_one_side():
+    """Offer-based create with one side filled (initiator) and the other empty (offer fills later)."""
+    maker, _ = _eth_perp_orders()
+    trade = Trade.fill(
+        market="ETH-USD-PERP",
+        price=Decimal("1500"),
+        size=Decimal("0.1"),
+        maker_order=maker,
+        taker_order=None,
     )
+    block_trade = BlockTrade(nonce="n", expiration=1700000000000, trades=[trade])
+    message = build_block_trade_message(1, block_trade)
 
-    # Create trades
-    trades = [
-        Trade(
-            price=Decimal("1500.50"),
-            size=Decimal("0.1"),
-            maker_order=maker_order1,
-            taker_order=taker_order1,
-        ),
-        Trade(
-            price=Decimal("45000.75"),
-            size=Decimal("0.01"),
-            maker_order=maker_order2,
-            taker_order=taker_order2,
-        ),
+    leaf = message["message"]["trades"][0]
+    assert leaf["maker_order"]["account"] == "0xMAKER"
+    assert leaf["taker_order"] == {
+        "account": "0",
+        "side": "0",
+        "type": "0",
+        "size": "0",
+        "price": "0",
+    }
+
+
+def test_build_block_trade_message_sorts_by_market():
+    """Leaves are canonically sorted by market (alphabetical) regardless of input order.
+    Without this the merkle root diverges from the server, which sorts independently."""
+    maker, taker = _eth_perp_orders()
+    eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, taker)
+    btc = Trade.fill("BTC-USD-PERP", Decimal("45000"), Decimal("0.01"), maker, taker)
+
+    bt_eth_first = BlockTrade(nonce="n", expiration=1700000000000, trades=[eth, btc])
+    bt_btc_first = BlockTrade(nonce="n", expiration=1700000000000, trades=[btc, eth])
+
+    msg_eth_first = build_block_trade_message(1, bt_eth_first)
+    msg_btc_first = build_block_trade_message(1, bt_btc_first)
+
+    # Same trades, different input order — canonical sort produces the SAME message.
+    assert msg_eth_first == msg_btc_first
+    # And the canonical order is alphabetical: BTC before ETH.
+    assert msg_eth_first["message"]["trades"][0]["market"] == "BTC-USD-PERP"
+    assert msg_eth_first["message"]["trades"][1]["market"] == "ETH-USD-PERP"
+
+
+def test_build_block_trade_offer_message_sorts_by_market():
+    maker, _ = _eth_perp_orders()
+    eth = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, None)
+    btc = Trade.fill("BTC-USD-PERP", Decimal("45000"), Decimal("0.01"), maker, None)
+
+    offer_eth_first = BlockTradeOffer(nonce="o", expiration=1700000000000, block_trade_id="P", trades=[eth, btc])
+    offer_btc_first = BlockTradeOffer(nonce="o", expiration=1700000000000, block_trade_id="P", trades=[btc, eth])
+
+    msg_a = build_block_trade_offer_message(1, offer_eth_first)
+    msg_b = build_block_trade_offer_message(1, offer_btc_first)
+
+    assert msg_a == msg_b
+    assert msg_a["message"]["trades"][0]["market"] == "BTC-USD-PERP"
+
+
+def test_build_block_trade_offer_message_schema():
+    """Offer typed-data has primaryType BlockTradeOffer and binds block_trade_id."""
+    maker, _ = _eth_perp_orders()
+    trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, None)
+    offer = BlockTradeOffer(
+        nonce="o1",
+        expiration=1700000000000,
+        block_trade_id="parent_block_xyz",
+        trades=[trade],
+    )
+    message = build_block_trade_offer_message(7, offer)
+
+    assert message["primaryType"] == "BlockTradeOffer"
+    assert message["domain"]["chainId"] == "0x7"
+    assert message["domain"]["revision"] == "1"
+    assert message["message"]["block_trade_id"] == "parent_block_xyz"
+    assert message["types"]["BlockTradeOffer"] == [
+        {"name": "version", "type": "shortstring"},
+        {"name": "nonce", "type": "felt"},
+        {"name": "expiration", "type": "felt"},
+        {"name": "block_trade_id", "type": "felt"},
+        {"name": "trades", "type": "merkletree", "contains": "Trade"},
     ]
 
-    # Create block trade
-    block_trade = BlockTrade(version="2.0", trades=trades)
 
-    # Test message building
-    message = build_block_trade_message(5, block_trade)
+def test_block_trade_offer_distinct_primary_type():
+    """BlockTrade and BlockTradeOffer are cryptographically domain-separated by primaryType.
+    Even with identical trade leaves, the typed-data messages differ — so signatures
+    cannot be replayed across the two flows."""
+    maker, taker = _eth_perp_orders()
+    trade = Trade.fill("ETH-USD-PERP", Decimal("1500"), Decimal("0.1"), maker, taker)
 
-    # Verify structure
-    assert message["domain"]["chainId"] == "0x5"
-    assert message["primaryType"] == "BlockTrade"
-    assert message["message"]["version"] == "2.0"
-    assert len(message["message"]["trades"]) == 2
+    bt = BlockTrade(nonce="x", expiration=1700000000000, trades=[trade])
+    offer = BlockTradeOffer(nonce="x", expiration=1700000000000, block_trade_id="P", trades=[trade])
 
-    # Verify first trade
-    trade1 = message["message"]["trades"][0]
-    assert trade1["price"] == "150050000000"  # 1500.50 * 10^8
-    assert trade1["size"] == "10000000"  # 0.1 * 10^8
-    assert trade1["maker_order"]["market"] == "ETH-USD-PERP"
-    assert trade1["maker_order"]["side"] == "1"  # Buy
-    assert trade1["taker_order"]["side"] == "2"  # Sell
+    bt_msg = build_block_trade_message(1, bt)
+    offer_msg = build_block_trade_offer_message(1, offer)
 
-    # Verify second trade
-    trade2 = message["message"]["trades"][1]
-    assert trade2["price"] == "4500075000000"  # 45000.75 * 10^8
-    assert trade2["size"] == "1000000"  # 0.01 * 10^8
-    assert trade2["maker_order"]["market"] == "BTC-USD-PERP"
-    assert trade2["maker_order"]["side"] == "2"  # Sell
-    assert trade2["maker_order"]["orderType"] == "MARKET"
-    assert trade2["maker_order"]["price"] == "0"  # Market order
-    assert trade2["taker_order"]["side"] == "1"  # Buy
+    assert bt_msg["primaryType"] != offer_msg["primaryType"]
+    # The trades arrays would match if we strip primary-type-specific fields, but the
+    # TYPE_HASH derived from primaryType differs, so messageHash is domain-separated.
+
+
+class _FakeOrder:
+    """Minimal stand-in for a server-returned BlockTradeOrder DTO (Pydantic-like)."""
+
+    def __init__(self, account, side_value, type_value, size, price):
+        self.account = account
+
+        class _Enum:
+            def __init__(self, value):
+                self.value = value
+
+        self.side = _Enum(side_value)
+        self.type = _Enum(type_value)
+        self.size = size
+        self.price = price
+
+
+class _FakeTradeDetail:
+    def __init__(self, *, maker_order=None, taker_order=None, price="0", size="0", trade_constraints=None):
+        self.maker_order = maker_order
+        self.taker_order = taker_order
+        self.price = price
+        self.size = size
+        self.trade_constraints = trade_constraints
+
+
+class _FakeBlockResponse:
+    def __init__(self, trades_dict):
+        self.trades = trades_dict
+
+
+def test_block_trade_from_response_fill():
+    """Reconstruct a signing-shape BlockTrade from a server response containing fill trades."""
+    maker_dto = _FakeOrder("0xMAKER", "SELL", "LIMIT", "0.1", "1500")
+    taker_dto = _FakeOrder("0xTAKER", "BUY", "LIMIT", "0.1", "1500")
+    response = _FakeBlockResponse(
+        {"ETH-USD-PERP": _FakeTradeDetail(maker_order=maker_dto, taker_order=taker_dto, price="1500", size="0.1")}
+    )
+
+    bt = block_trade_from_response(response, nonce="executor_nonce", expiration=1700000000000)
+    assert bt.nonce == "executor_nonce"
+    assert bt.expiration == 1700000000000
+    assert len(bt.trades) == 1
+    leaf = bt.trades[0]
+    assert leaf.market == "ETH-USD-PERP"
+    assert leaf.price == Decimal("1500")
+    assert leaf.size == Decimal("0.1")
+    assert leaf.maker_order.account == "0xMAKER"
+    assert leaf.maker_order.side == "SELL"
+    assert leaf.taker_order.account == "0xTAKER"
+    assert leaf.taker_order.side == "BUY"
+    # Constraints zero (fill leaf)
+    assert leaf.min_size == Decimal(0)
+    assert leaf.max_size == Decimal(0)
+
+
+class _FakeConstraints:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+def test_block_trade_message_hash_pinned():
+    """Pin the messageHash for a fixed BlockTrade input. Tied to the schema, encoding,
+    leaf-sort, and domain definitions — any change to any of those flips this hash, so
+    an equivalent verifier (e.g. a server) producing the same hash for the same inputs
+    confirms the two implementations stay aligned."""
+    from starknet_py.utils.typed_data import TypedData
+
+    maker_address = "0x1111"
+    taker_address = "0x2222"
+    maker_btc = BlockTradeOrder(maker_address, "SELL", "LIMIT", Decimal("0.1"), Decimal("73000"))
+    taker_btc = BlockTradeOrder(taker_address, "BUY", "LIMIT", Decimal("0.1"), Decimal("73000"))
+    maker_eth = BlockTradeOrder(maker_address, "SELL", "LIMIT", Decimal("1"), Decimal("3000"))
+    taker_eth = BlockTradeOrder(taker_address, "BUY", "LIMIT", Decimal("1"), Decimal("3000"))
+    # Trades intentionally in non-canonical (ETH before BTC) input order — the sort happens
+    # at the cryptographic boundary, so the hash is invariant to input order.
+    block_trade = BlockTrade(
+        nonce="1234567890",
+        expiration=1700000000000,
+        trades=[
+            Trade.fill("ETH-USD-PERP", Decimal("3000"), Decimal("1"), maker_eth, taker_eth),
+            Trade.fill("BTC-USD-PERP", Decimal("73000"), Decimal("0.1"), maker_btc, taker_btc),
+        ],
+    )
+
+    typed_data = TypedData.from_dict(build_block_trade_message(1, block_trade))
+    actual = f"0x{typed_data.message_hash(int(maker_address, 16)):x}"
+    assert actual == "0x426f5dd572deed472db9aa9ac2469f4a456a3a72854b723065daf3ccc350812"
+
+
+def test_block_trade_offer_message_hash_pinned():
+    """Pin the messageHash for a fixed BlockTradeOffer input. Distinct from the BlockTrade
+    hash — domain-separated by primaryType + the block_trade_id binding. Same pinning
+    rationale as above."""
+    from starknet_py.utils.typed_data import TypedData
+
+    maker_address = "0x1111"
+    maker_btc = BlockTradeOrder(maker_address, "SELL", "LIMIT", Decimal("0.1"), Decimal("73000"))
+    maker_eth = BlockTradeOrder(maker_address, "SELL", "LIMIT", Decimal("1"), Decimal("3000"))
+    # Offerer occupies maker side only; taker side is None (empty leaf, encoded as zero).
+    offer = BlockTradeOffer(
+        nonce="offer_nonce_1",
+        expiration=1700000300000,
+        block_trade_id="parent_block_xyz",
+        trades=[
+            Trade.fill("ETH-USD-PERP", Decimal("3000"), Decimal("1"), maker_eth, None),
+            Trade.fill("BTC-USD-PERP", Decimal("73000"), Decimal("0.1"), maker_btc, None),
+        ],
+    )
+
+    typed_data = TypedData.from_dict(build_block_trade_offer_message(1, offer))
+    actual = f"0x{typed_data.message_hash(int(maker_address, 16)):x}"
+    assert actual == "0x3d43168f6def95bf9371aae3b20a2e9713e91a773b1a192f5e0729e96b7b139"
+
+
+def test_block_trade_from_response_constraint_only():
+    """Offer-based parent: server returns trade_constraints, no maker/taker orders."""
+    constraints = _FakeConstraints(
+        min_size="0.05", max_size="1.0", min_price="29000", max_price="31000", oracle_tolerance="0.02"
+    )
+    response = _FakeBlockResponse({"BTC-USD-PERP": _FakeTradeDetail(trade_constraints=constraints)})
+
+    bt = block_trade_from_response(response, nonce="n", expiration=1700000000000)
+    assert len(bt.trades) == 1
+    leaf = bt.trades[0]
+    assert leaf.market == "BTC-USD-PERP"
+    assert leaf.min_size == Decimal("0.05")
+    assert leaf.max_price == Decimal("31000")
+    assert leaf.maker_order is None
+    assert leaf.taker_order is None


### PR DESCRIPTION
## Summary

Brings block-trade signing in line with the server's rev2 schema:

- **SNIP-12 revision 1 (Poseidon) typed data** — `BlockTrade` payload
    now uses `revision: "1"`, `StarknetDomain`, and a `merkletree` of
    `Trade` leaves so a single signature commits to all trades
    atomically. Schema bump to `version = "2"`.
- **`BlockTradeOffer` typed data** — distinct primary type from
    `BlockTrade`, cryptographically domain-separated. Binds an offer to
    its parent via `block_trade_id`, so an offer signed for parent A
    cannot be replayed against parent B.
- **`Trade` is a fill-or-constraint union** — `Trade.fill(...)` for
    direct/offer trades, `Trade.constraint(...)` for offer-based parent
    blocks. Both share the same on-wire schema with unused fields
    zeroed, so the merkle root commits to the absence of the other
    variant.
- **Canonical leaf ordering** — trades are sorted alphabetically by
    `market` before hashing. Matches the Go server's sorted-map
    iteration; without this, multi-market blocks would only verify by
    chance.
- **`signer_public_key`** added to `BlockTradeSignature` — lets the
    server look up the right pubkey (main account or active subkey)
    without guessing.

### High-level helpers on `ParadexAccount`

- `build_block_trade_signature(block_trade)` → full
  `BlockTradeSignature` ready to attach to
  `BlockTradeRequest.signatures` / `BlockExecuteRequest.signatures`.
- `build_block_trade_offer_signature(offer)` → full
  `BlockTradeSignature` for `BlockOfferRequest.signature`.
- `build_executor_signature_for_block(block_response)` → executor-side
  signature dict for a DIRECT block execute (keyed by `block_id`).
- `build_executor_signatures_for_offers(offer_responses)` →
  executor-side signature dict for an OFFER-BASED execute (keyed by
  `offer_id`, one entry per offer).
- `block_trade_from_response(response, nonce, expiration)` reconstructs
  the signing `BlockTrade` from a `BlockTradeDetailFullResponse` so
  executors can re-sign the merkle root the server will recompute.

The lower-level `sign_block_trade` / `sign_block_trade_offer` (returning
the raw `[r,s]` string) are still available; most callers should use
the `build_*_signature` helpers which auto-populate metadata.

### Removed

- `sign_block_offer` (legacy duplicate of `sign_block_trade` from the
  pre-rev2 design).

