### PR TITLE
Add threaded WebSocket client for synchronous usage (rebase of #121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ print(hex(paradex.account.l2_private_key)) # 0x...
 
 ### WebSocket Usage
 
+The SDK provides two WebSocket client options:
+
+#### Option 1: Async Client (Default)
+
+Use the async client when you're comfortable with asyncio and need maximum performance:
+
 ```python
 async def on_message(ws_channel, message):
     print(ws_channel, message)
@@ -49,13 +55,44 @@ await paradex.ws_client.connect()
 await paradex.ws_client.subscribe(ParadexWebsocketChannel.MARKETS_SUMMARY, callback=on_message)
 ```
 
+#### Option 2: Threaded Client (Synchronous)
+
+Use the threaded client for simpler integration without asyncio knowledge:
+
+```python
+from paradex_py.api.ws_client_threaded import ThreadedParadexWebsocketClient
+from paradex_py.api.ws_client import ParadexWebsocketChannel
+from paradex_py.environment import TESTNET
+
+# Simple synchronous usage - no asyncio required
+ws_client = ThreadedParadexWebsocketClient(env=TESTNET)
+
+with ws_client:
+    ws_client.subscribe(ParadexWebsocketChannel.MARKETS_SUMMARY)
+
+    # Blocking call - waits for messages
+    msg = ws_client.get_updates(timeout=5.0)
+    if msg:
+        print(f"Channel: {msg.channel}, Data: {msg.data}")
+```
+
+**When to use which:**
+| Feature | Async Client | Threaded Client |
+|---------|-------------|-----------------|
+| Asyncio knowledge | Required | Not required |
+| Integration | Async codebases | Synchronous codebases |
+| Performance | Optimal | Good |
+| Complexity | Higher | Lower |
+| Runtime subscription | Via callbacks | Via `subscribe()` anytime |
+
 📖 For complete documentation refer to [tradeparadex.github.io/paradex-py](https://tradeparadex.github.io/paradex-py/)
 
 💻 For comprehensive examples refer to following files:
 
 - API (L1+L2): [examples/call_rest_api.py](examples/call_rest_api.py)
 - API (L2-only): [examples/subkey_rest_api.py](examples/subkey_rest_api.py)
-- WS (L1+L2): [examples/connect_ws_api.py](examples/connect_ws_api.py)
+- WS Async (L1+L2): [examples/connect_ws_api.py](examples/connect_ws_api.py)
+- WS Threaded: [examples/connect_ws_threaded.py](examples/connect_ws_threaded.py)
 - WS (L2-only): [examples/subkey_ws_api.py](examples/subkey_ws_api.py)
 - Transfer: [examples/transfer_l2_usdc.py](examples/transfer_l2_usdc.py)
 

--- a/examples/connect_ws_threaded.py
+++ b/examples/connect_ws_threaded.py
@@ -1,0 +1,55 @@
+"""Example: Using the threaded WebSocket client for synchronous integration.
+
+This demonstrates the synchronous API that doesn't require asyncio knowledge.
+For the async version see `examples/connect_ws_api.py`.
+"""
+
+import os
+
+from examples.utils import get_logger
+from paradex_py import Paradex
+from paradex_py.api.ws_client import ParadexWebsocketChannel
+from paradex_py.api.ws_client_threaded import ThreadedParadexWebsocketClient
+from paradex_py.environment import TESTNET
+
+TEST_L1_ADDRESS = os.getenv("L1_ADDRESS", "")
+TEST_L1_PRIVATE_KEY = os.getenv("L1_PRIVATE_KEY", "")
+
+
+def main() -> None:
+    logger = get_logger(__name__)
+
+    Paradex(
+        env=TESTNET,
+        l1_address=TEST_L1_ADDRESS,
+        l1_private_key=TEST_L1_PRIVATE_KEY,
+        logger=logger,
+    )
+
+    ws_client = ThreadedParadexWebsocketClient(env=TESTNET)
+
+    try:
+        with ws_client:
+            logger.info("WebSocket connected")
+
+            ws_client.subscribe(ParadexWebsocketChannel.MARKETS_SUMMARY)
+            ws_client.subscribe(ParadexWebsocketChannel.BBO)
+            logger.info("Subscribed to MARKETS_SUMMARY and BBO")
+
+            message_count = 0
+            while message_count < 100:
+                msg = ws_client.get_updates(timeout=5.0)
+                if msg:
+                    message_count += 1
+                    logger.info("[%d] %s: %s", message_count, msg.channel, msg.data)
+                else:
+                    logger.info("No message received (timeout)")
+
+            logger.info("Received %d messages", message_count)
+
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+
+
+if __name__ == "__main__":
+    main()

--- a/paradex_py/api/ws_client_threaded.py
+++ b/paradex_py/api/ws_client_threaded.py
@@ -1,0 +1,133 @@
+"""
+Thread-based WebSocket client wrapper (built on sv/ws-reconnect).
+
+This enhancement wraps the reconnect-aware async client in a background thread,
+providing the simple synchronous interface requested in Issue #55.
+
+Works seamlessly with the reconnection logic from sv/ws-reconnect branch.
+"""
+
+import asyncio
+import logging
+import queue
+import threading
+from dataclasses import dataclass
+
+from paradex_py.api.ws_client import ParadexWebsocketChannel, ParadexWebsocketClient
+from paradex_py.environment import Environment
+
+
+@dataclass
+class WSMessage:
+    """Message from WebSocket."""
+
+    channel: str
+    data: dict
+
+
+class ThreadedParadexWebsocketClient:
+    """
+    Synchronous wrapper around async ParadexWebsocketClient.
+
+    Solves Issue #55: Makes WebSocket easier to use without asyncio knowledge.
+
+    Usage:
+        client = ThreadedParadexWebsocketClient(env=Environment.TESTNET)
+        with client:
+            client.subscribe(ParadexWebsocketChannel.ACCOUNT)
+            msg = client.get_updates(timeout=1.0)
+    """
+
+    def __init__(self, env: Environment):
+        self.env = env
+        self.message_queue: queue.Queue = queue.Queue(maxsize=1000)
+
+        self._ws_client: ParadexWebsocketClient | None = None
+        self._ws_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._connected_event = threading.Event()
+        self.logger = logging.getLogger(__name__)
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def connect(self, timeout: float = 10.0) -> bool:
+        """Connect to WebSocket in background thread."""
+        self._stop_event.clear()
+        self._connected_event.clear()
+
+        self._ws_thread = threading.Thread(
+            target=self._run_event_loop,
+            daemon=False,
+        )
+        self._ws_thread.start()
+
+        return self._connected_event.wait(timeout=timeout)
+
+    def subscribe(self, channel: ParadexWebsocketChannel) -> None:
+        """Subscribe to a WebSocket channel."""
+        self.message_queue.put(("_subscribe", channel))
+
+    def get_updates(self, timeout: float | None = None) -> WSMessage | None:
+        """Get next message (blocking)."""
+        try:
+            msg_type, data = self.message_queue.get(timeout=timeout)
+        except queue.Empty:
+            return None
+        else:
+            if msg_type.startswith("_"):
+                return self.get_updates(timeout=timeout)
+            return WSMessage(channel=msg_type, data=data)
+
+    def close(self) -> None:
+        """Close connection and cleanup."""
+        self._stop_event.set()
+        if self._ws_thread:
+            self._ws_thread.join(timeout=5.0)
+
+    def _run_event_loop(self) -> None:
+        """Run asyncio event loop in background thread."""
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(self._async_loop())
+        finally:
+            loop.close()
+
+    async def _async_loop(self) -> None:
+        """Main async loop using the reconnect-aware client."""
+        try:
+
+            def _on_message(channel: str, message: dict) -> None:
+                self.message_queue.put((channel, message))
+
+            self._ws_client = ParadexWebsocketClient(
+                env=self.env,
+                auto_start_reader=True,
+            )
+
+            self._connected_event.set()
+            await self._ws_client.connect()
+
+            while not self._stop_event.is_set():
+                try:
+                    # Check for subscribe commands
+                    try:
+                        cmd, channel = self.message_queue.get_nowait()
+                        if cmd == "_subscribe":
+                            await self._ws_client.subscribe(channel, callback=_on_message)
+                    except queue.Empty:
+                        pass
+
+                    await asyncio.sleep(0.05)
+
+                except asyncio.TimeoutError:
+                    continue
+
+        finally:
+            if self._ws_client:
+                await self._ws_client.close()

--- a/tests/api/test_ws_client_threaded.py
+++ b/tests/api/test_ws_client_threaded.py
@@ -1,0 +1,28 @@
+"""Tests for threaded WebSocket client."""
+
+from paradex_py.api.ws_client_threaded import (
+    ThreadedParadexWebsocketClient,
+    WSMessage,
+)
+from paradex_py.environment import TESTNET
+
+
+class TestThreadedParadexWebsocketClient:
+    """Test cases for threaded WebSocket client."""
+
+    def test_instantiate(self):
+        """Test basic instantiation."""
+        client = ThreadedParadexWebsocketClient(env=TESTNET)
+        assert client is not None
+
+    def test_message_dataclass(self):
+        """Test WSMessage dataclass."""
+        msg = WSMessage(channel="test", data={"key": "value"})
+        assert msg.channel == "test"
+        assert msg.data == {"key": "value"}
+
+    def test_queue_isolation(self):
+        """Test that each client has isolated message queue."""
+        client1 = ThreadedParadexWebsocketClient(env=TESTNET)
+        client2 = ThreadedParadexWebsocketClient(env=TESTNET)
+        assert client1.message_queue is not client2.message_queue


### PR DESCRIPTION
## Summary

Replays PR #121 (threaded WebSocket client, by @yodablocks / @MLiserb) on top of current `main` with the quality issues blocking that PR fixed:

- Cherry-picked the three content commits from #121 with authorship preserved (`a725e8a`, `6c2d804`, `1a062cb`).
- Applied auto-fixes from `make check`: `ruff format`, `end-of-file-fixer`, `trim trailing whitespace`, and dropping an unused `import pytest`.

This is opened from an upstream branch because #121 lives on a fork that the maintainer can't edit. Original credit remains on the three picked commits; the fourth commit only contains the lint auto-fixes. Closes #121.

## Changes

- `paradex_py/api/ws_client_threaded.py` – new `ThreadedParadexWebsocketClient` synchronous wrapper around the async WS client
- `paradex_py/api/ws_message_models.py` – minor comment formatting (ruff)
- `tests/api/test_ws_client_threaded.py` – tests for instantiation, dataclass, queue isolation
- `examples/connect_ws_threaded.py` – usage example
- `README.md` – documentation with sync vs async comparison

## Verification

- `make check` passes (ruff/format/ty/deptry/prettier) ✅
- `uv run pytest tests/api/test_ws_client_threaded.py -v` → 3 passed ✅

Closes #121

https://claude.ai/code/session_01NJssFySWcjnci6c2fWmYEg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJssFySWcjnci6c2fWmYEg)_