### PR TITLE
ci: migrate Claude workflow to Bedrock (OIDC)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,22 +20,33 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
+      id-token: write # mandatory for OIDC — omitting causes silent auth failure
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
+      actions: read # lets Claude read CI results on PRs
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          fetch-depth: 1
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Configure AWS credentials (Bedrock via OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: eu-west-2
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: eu.anthropic.claude-opus-4-8
+          use_bedrock: "true"
+          github_token: ${{ steps.app-token.outputs.token }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-name: Claude Code
+name: Claude
 
 on:
   issue_comment:
@@ -19,31 +19,30 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
+      id-token: write      # mandatory for OIDC — omitting causes silent auth failure
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read        # lets Claude read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          fetch-depth: 1
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Run Claude Code
-        id: claude
+      - name: Configure AWS credentials (Bedrock via OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: eu-west-2
+
+      - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
+          model: eu.anthropic.claude-opus-4-8
+          use_bedrock: "true"
+          github_token: ${{ steps.app-token.outputs.token }}
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      id-token: write      # mandatory for OIDC — omitting causes silent auth failure
+      id-token: write # mandatory for OIDC — omitting causes silent auth failure
       contents: write
       pull-requests: write
       issues: write
-      actions: read        # lets Claude read CI results on PRs
+      actions: read # lets Claude read CI results on PRs
     steps:
       - name: Generate GitHub App token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Enables `@claude` via Amazon Bedrock + GitHub OIDC (no static API keys).

- Auth: OIDC -> IAM role `github-claude-bedrock` (acct 654650380203), Bedrock in eu-west-2, model `eu.anthropic.claude-opus-4-8`.
- Uses org secrets `AWS_ROLE_TO_ASSUME`, `APP_ID`, `APP_PRIVATE_KEY` (already set at org level, visibility=all).
- **Depends on** GitHub App `paradex-claude-bot` (app_id 3938294) being installed on this org. Merge once the app is installed.

Replaces the previous `ANTHROPIC_API_KEY`-based workflow (the secret was never set, so it was non-functional).