### PR TITLE
ci: fix Claude code-review (restore checkout step)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,11 @@ jobs:
       actions: read # lets Claude read CI results on PRs
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Generate GitHub App token
         uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
Follow-up to #155. The Bedrock migration of `claude-code-review.yml` dropped the `actions/checkout` step. The code-review path runs claude-code-action in **agent mode**, which expects a checked-out git repo (`git fetch origin main` -> `fatal: not a git repository`). This restores the checkout step.

Verified separately that OIDC->STS->Bedrock auth already works (the *Configure AWS credentials* step succeeds; this was the only remaining failure).