### PR TITLE
Support EIP-191 on-chain signing for Argent v0.5.0 (EVM) accounts

### DIFF
--- a/paradex_py/account/eip191_signer.py
+++ b/paradex_py/account/eip191_signer.py
@@ -1,0 +1,112 @@
+"""EIP-191 signer for Argent v0.5.0 (Eip191) Paradex accounts.
+
+An EVM-onboarded Paradex account is an Argent v0.5.0 account whose owner is an
+Ethereum (secp256k1) key, validated on-chain via EIP-191 ``personal_sign``.
+This signer plugs into ``starknet_py``'s ``Account`` in place of the stark-curve
+``KeyPair`` so the SDK can sign StarkNet transactions (and SNIP-12 messages) for
+such an account.
+
+How Argent validates an EIP-191 signature (argent-contracts-starknet v0.5.0,
+``src/signer/eip191.cairo`` ``calculate_eip191_hash`` /
+``is_valid_eip191_signature``):
+
+    secp256k1_verify(
+        keccak256("\\x19Ethereum Signed Message:\\n32" || felt_to_be32(tx_hash)),
+        eth_address,
+        signature,
+    )
+
+i.e. the StarkNet transaction hash (a felt) is right-padded to 32 bytes, run
+through the standard EIP-191 personal_sign envelope, and signed with secp256k1.
+``eth_account.sign_message(encode_defunct(primitive=<32 bytes>))`` produces
+exactly that.
+
+The signature is serialized as Argent's ``SignerSignature`` span
+(``src/signer/signer_signature.cairo``), wrapped in the account's
+``parse_account_signature`` ``[count, ...]`` envelope::
+
+    [1, 3, eth_address, r.low, r.high, s.low, s.high, y_parity]
+     │  │  │            └──────── Secp256Signature {r:u256, s:u256, y_parity} ───────┘
+     │  │  └─ Eip191Signer { eth_address }
+     │  └─ SignerSignature::Eip191 variant index
+     └─ signature count = 1 (owner only; no guardian)
+"""
+
+from eth_account import Account as EthAccount
+from eth_account.messages import encode_defunct
+from starknet_py.net.models import AccountTransaction
+from starknet_py.net.signer import BaseSigner
+from starknet_py.utils.typed_data import TypedData
+
+# SignerSignature::Eip191 enum variant index (signer_signature.cairo).
+_EIP191_SIGNER_VARIANT = 3
+# parse_account_signature envelope: 1 signer signature (owner only, no guardian).
+_OWNER_ONLY_COUNT = 1
+_U128_MASK = (1 << 128) - 1
+
+
+def _u256_low_high(value: int) -> tuple[int, int]:
+    return value & _U128_MASK, value >> 128
+
+
+def _serialize_eip191_signer_signature(eth_address: int, r: int, s: int, y_parity: int) -> list[int]:
+    """Serialize the owner ``SignerSignature`` span for an Eip191 account."""
+    r_low, r_high = _u256_low_high(r)
+    s_low, s_high = _u256_low_high(s)
+    return [
+        _OWNER_ONLY_COUNT,
+        _EIP191_SIGNER_VARIANT,
+        eth_address,
+        r_low,
+        r_high,
+        s_low,
+        s_high,
+        y_parity,
+    ]
+
+
+def sign_hash_eip191(message_hash: int, eth_private_key: str) -> list[int]:
+    """Sign a StarkNet felt hash for an Argent Eip191 account.
+
+    Returns the serialized ``SignerSignature`` span (with the owner-only count
+    prefix) ready to use as a transaction/message signature.
+    """
+    digest = message_hash.to_bytes(32, "big")
+    signed = EthAccount.sign_message(encode_defunct(primitive=digest), eth_private_key)
+    eth_address = int(EthAccount.from_key(eth_private_key).address, 16)
+    # eth_account returns v in {27, 28}; Argent's Secp256Signature wants y_parity {0, 1}.
+    y_parity = signed.v - 27
+    return _serialize_eip191_signer_signature(eth_address, signed.r, signed.s, y_parity)
+
+
+class Eip191Signer(BaseSigner):
+    """A ``starknet_py`` signer that signs with an Ethereum key via EIP-191.
+
+    Drop-in for the stark-curve ``KeyPair`` when the Paradex account is an
+    Argent v0.5.0 Eip191 account. ``public_key`` returns the Ethereum address as
+    an int (the account's on-chain owner identifier), not a stark pubkey.
+    """
+
+    def __init__(self, eth_private_key: str, chain_id: int):
+        # chain_id is the Paradex appchain id (a felt); accepted as a plain int
+        # so the custom CustomStarknetChainId enum can be passed through.
+        self._eth_private_key = eth_private_key
+        self._eth_address = int(EthAccount.from_key(eth_private_key).address, 16)
+        self.chain_id = chain_id
+
+    @property
+    def private_key(self) -> int:
+        return int(self._eth_private_key, 16) if isinstance(self._eth_private_key, str) else int(self._eth_private_key)
+
+    @property
+    def public_key(self) -> int:
+        # The Eip191 account's owner is identified by its Ethereum address.
+        return self._eth_address
+
+    def sign_transaction(self, transaction: AccountTransaction) -> list[int]:
+        tx_hash = transaction.calculate_hash(self.chain_id)
+        return sign_hash_eip191(tx_hash, self._eth_private_key)
+
+    def sign_message(self, typed_data: TypedData, account_address: int) -> list[int]:
+        msg_hash = typed_data.message_hash(account_address)
+        return sign_hash_eip191(msg_hash, self._eth_private_key)

--- a/paradex_py/account/evm_account.py
+++ b/paradex_py/account/evm_account.py
@@ -1,12 +1,19 @@
 import base64
 import secrets
+import types
 from datetime import datetime, timedelta, timezone
 
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_keys.datatypes import PrivateKey
-from starknet_py.common import int_from_hex
+from httpx import AsyncClient
+from starknet_py.common import int_from_bytes, int_from_hex
+from starknet_py.net.full_node_client import FullNodeClient
+from starknet_py.net.http_client import HttpMethod
 
+from paradex_py.account.account import CustomStarknetChainId
+from paradex_py.account.eip191_signer import Eip191Signer
+from paradex_py.account.starknet import Account as StarknetAccount
 from paradex_py.account.utils import derive_l2_address_eip191
 from paradex_py.api.models import SystemConfig
 from paradex_py.environment import Environment
@@ -53,6 +60,7 @@ class EvmAccount:
         evm_private_key: str,
         l2_address: str | None = None,
         is_onboarded: bool | None = None,
+        rpc_version: str | None = None,
     ):
         if not evm_address:
             raise_value_error("EvmAccount: EVM address is required")
@@ -61,6 +69,8 @@ class EvmAccount:
 
         self.config = config
         self.env = env
+        self._evm_private_key = evm_private_key
+        self._rpc_version = rpc_version
 
         # Normalise address to checksum format
         self._eth_account = Account.from_key(evm_private_key)
@@ -81,6 +91,62 @@ class EvmAccount:
             # construction and is intended for eventual removal.
             self.l2_address = derive_l2_address_eip191(config, self.evm_address)
         self.is_onboarded = is_onboarded
+
+        # StarkNet account backed by an EIP-191 signer, so on-chain operations
+        # (deposit / withdraw / transfer / guardian) can be signed with the
+        # Ethereum key. The account contract validates the resulting
+        # SignerSignature via secp256k1/EIP-191 on-chain.
+        self.l2_chain_id = int_from_bytes(config.starknet_chain_id.encode())
+        self.jwt_token: str | None = None
+        self.starknet = self._build_starknet_account()
+        self._apply_fullnode_jwt_patch(self.starknet.client)
+
+    def _apply_fullnode_jwt_patch(self, client) -> None:
+        """Attach the account's JWT to fullnode RPC requests.
+
+        An EVM account authenticates with the ``Authorization: Bearer <jwt>``
+        token obtained during SIWE auth and sends it on each RPC call.
+        """
+        current_self = self
+
+        # Skip starknet_py's RPC spec-version probe (it only emits a warning on
+        # mismatch); the endpoint may report a newer spec than the pinned
+        # EXPECTED_RPC_VERSION.
+        client._client._is_spec_version_verified = True
+
+        async def jwt_make_request(
+            self,
+            session: AsyncClient,
+            address: str,
+            http_method: HttpMethod,
+            params: dict,
+            payload: dict,
+        ) -> dict:
+            headers = {"Content-Type": "application/json"}
+            if current_self.jwt_token:
+                headers["Authorization"] = f"Bearer {current_self.jwt_token}"
+            response = await session.request(
+                method=http_method.value, url=address, params=params, json=payload, headers=headers
+            )
+            await self.handle_request_error(response)
+            return await response.json()
+
+        client._client._make_request = types.MethodType(jwt_make_request, client._client)
+
+    def _build_starknet_account(self) -> StarknetAccount:
+        if self._rpc_version:
+            node_url = f"{self.config.starknet_fullnode_rpc_base_url}/rpc/{self._rpc_version}"
+        else:
+            node_url = self.config.starknet_fullnode_rpc_url
+        client = FullNodeClient(node_url=node_url)
+        chain = CustomStarknetChainId(self.l2_chain_id)
+        signer = Eip191Signer(self._evm_private_key, int(chain))
+        return StarknetAccount(
+            client=client,
+            address=self.l2_address,
+            signer=signer,
+            chain=chain,  # ty: ignore[invalid-argument-type]
+        )
 
     # ------------------------------------------------------------------
     # SIWE helpers

--- a/tests/account/test_eip191_signer.py
+++ b/tests/account/test_eip191_signer.py
@@ -1,0 +1,75 @@
+"""Tests for the EIP-191 signer used by Argent v0.5.0 (Eip191) accounts."""
+
+from unittest.mock import MagicMock
+
+from eth_account import Account as EthAccount
+from eth_account.messages import encode_defunct
+
+from paradex_py.account.eip191_signer import (
+    Eip191Signer,
+    sign_hash_eip191,
+)
+
+# Anvil dev key #1 — test fixture only, never funded.
+EVM_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+EVM_ADDR = EthAccount.from_key(EVM_KEY).address
+CHAIN_ID = 0x534E5F5345504F4C4941  # arbitrary felt chain id for tests
+
+
+def _recover(sig, message_hash):
+    """Recover the signer address from a serialized SignerSignature span."""
+    _count, _variant, _eth, r_lo, r_hi, s_lo, s_hi, y = sig
+    r = r_lo + (r_hi << 128)
+    s = s_lo + (s_hi << 128)
+    digest = message_hash.to_bytes(32, "big")
+    return EthAccount.recover_message(encode_defunct(primitive=digest), vrs=(y + 27, r, s))
+
+
+def test_sign_hash_envelope_and_variant():
+    sig = sign_hash_eip191(0xABCDEF, EVM_KEY)
+    assert sig[0] == 1  # owner-only count
+    assert sig[1] == 3  # SignerSignature::Eip191 variant
+    assert sig[2] == int(EVM_ADDR, 16)  # Eip191Signer.eth_address
+    assert len(sig) == 8  # count, variant, eth, r.lo, r.hi, s.lo, s.hi, y_parity
+
+
+def test_sign_hash_recovers_to_owner_address():
+    """The signature must recover to the account's ETH address — exactly what
+    Argent's on-chain secp256k1_verify(calculate_eip191_hash(...)) checks."""
+    h = 0x123456789ABCDEF
+    sig = sign_hash_eip191(h, EVM_KEY)
+    assert _recover(sig, h) == EVM_ADDR
+
+
+def test_u256_split_roundtrips():
+    # r/s are split into u256 {low, high}; recompose must equal the original.
+    big_hash = (1 << 250) - 7
+    sig = sign_hash_eip191(big_hash, EVM_KEY)
+    r = sig[3] + (sig[4] << 128)
+    s = sig[5] + (sig[6] << 128)
+    assert 0 < r < (1 << 256)
+    assert 0 < s < (1 << 256)
+    assert _recover(sig, big_hash) == EVM_ADDR
+
+
+def test_signer_public_key_is_eth_address():
+    signer = Eip191Signer(EVM_KEY, CHAIN_ID)
+    assert signer.public_key == int(EVM_ADDR, 16)
+
+
+def test_signer_sign_transaction_hashes_tx():
+    signer = Eip191Signer(EVM_KEY, CHAIN_ID)
+    tx = MagicMock()
+    tx.calculate_hash.return_value = 0xDEADBEEF
+    sig = signer.sign_transaction(tx)
+    tx.calculate_hash.assert_called_once_with(CHAIN_ID)
+    assert _recover(sig, 0xDEADBEEF) == EVM_ADDR
+
+
+def test_signer_sign_message_hashes_typed_data():
+    signer = Eip191Signer(EVM_KEY, CHAIN_ID)
+    td = MagicMock()
+    td.message_hash.return_value = 0xC0FFEE
+    sig = signer.sign_message(td, account_address=0x123)
+    td.message_hash.assert_called_once_with(0x123)
+    assert _recover(sig, 0xC0FFEE) == EVM_ADDR

--- a/tests/account/test_evm_account_onchain.py
+++ b/tests/account/test_evm_account_onchain.py
@@ -1,0 +1,56 @@
+"""Tests that EvmAccount wires a StarkNet account backed by the EIP-191 signer,
+so on-chain operations (deposit/withdraw/transfer/guardian) can be signed with
+the Ethereum key."""
+
+from eth_account import Account as EthAccount
+
+from paradex_py.account.eip191_signer import Eip191Signer
+from paradex_py.account.evm_account import EvmAccount
+from tests.mocks.api_client import MockApiClient
+
+# Throwaway EVM key (anvil dev key #2) — test fixture only.
+EVM_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+EVM_ADDR = EthAccount.from_key(EVM_KEY).address
+L2_ADDR = "0x51f2207a15e14b0a7b21e1b2ec3541f19380429f4269e8c65548170c4f7f2f8"
+
+
+def _account() -> EvmAccount:
+    config = MockApiClient().fetch_system_config()
+    return EvmAccount(
+        config=config,
+        env="testnet",
+        evm_address=EVM_ADDR,
+        evm_private_key=EVM_KEY,
+        l2_address=L2_ADDR,
+    )
+
+
+def test_evm_account_has_starknet_account_with_eip191_signer():
+    acct = _account()
+    assert hasattr(acct, "starknet")
+    assert isinstance(acct.starknet.signer, Eip191Signer)
+
+
+def test_starknet_account_address_is_l2_address():
+    acct = _account()
+    assert acct.starknet.address == int(L2_ADDR, 16)
+
+
+def test_signer_public_key_is_eth_address():
+    acct = _account()
+    assert acct.starknet.signer.public_key == int(EVM_ADDR, 16)
+
+
+def test_set_jwt_token_is_picked_up_for_rpc_auth():
+    acct = _account()
+    assert acct.jwt_token is None
+    token = "header.payload.sig"  # noqa: S105 — placeholder JWT, not a secret
+    acct.set_jwt_token(token)
+    assert acct.jwt_token == token
+
+
+def test_rpc_version_check_skipped_on_client():
+    # The proxy serves a newer spec version and gates the probe; the patch must
+    # mark the check done so the first real call doesn't error on it.
+    acct = _account()
+    assert acct.starknet.client._client._is_spec_version_verified is True


### PR DESCRIPTION
## What

Adds EIP-191 on-chain signing so EVM-onboarded Paradex accounts (Argent v0.5.0 accounts whose owner is an Ethereum/secp256k1 key) can sign and submit StarkNet transactions through the SDK — enabling deposit / withdraw / transfer / guardian operations, not just authentication.

## Background

The SDK could already onboard and authenticate an EVM account via SIWE, but its StarkNet signer is a stark-curve `KeyPair`, which cannot produce the EIP-191 `SignerSignature` the Argent v0.5.0 account validates. So an EVM account could authenticate but not transact on-chain.

## Changes

- **`Eip191Signer(BaseSigner)`** — signs a StarkNet transaction / SNIP-12 message hash using Argent's on-chain EIP-191 scheme: `keccak256("\x19Ethereum Signed Message:\n32" || felt_to_be32(hash))` signed with secp256k1, serialized as the Argent `SignerSignature` span `[1, 3, eth_address, r.lo, r.hi, s.lo, s.hi, y_parity]` (owner-only, Eip191 variant). Matches `argent-contracts-starknet` v0.5.0 (`src/signer/eip191.cairo`, `src/signer/signer_signature.cairo`).
- **`EvmAccount`** now builds a StarkNet account backed by `Eip191Signer`, so it can sign and submit invoke transactions; RPC requests carry the account's bearer JWT from SIWE auth.

## Testing

- Unit tests: signature serialization, recovery to the owner ETH address (the same check the account contract performs), and the `EvmAccount` on-chain wiring.
- Live on Sepolia testnet against a real Argent v0.5.0 Eip191 account: `sign_invoke_v3(auto_estimate=True)` is accepted on-chain — the account contract validates the EIP-191 signature during fee estimation.
- Full suite: **495 passed**; `ruff` clean.