### PR TITLE
Support system config as an input on ParadexSubkey

### DIFF
--- a/paradex_py/paradex_l2.py
+++ b/paradex_py/paradex_l2.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 from paradex_py._client_base import _ClientBase
 from paradex_py.account.subkey_account import SubkeyAccount
@@ -7,6 +8,9 @@ from paradex_py.api.ws_client import ParadexWebsocketClient
 from paradex_py.auth_level import AuthLevel
 from paradex_py.environment import Environment, _validate_env
 from paradex_py.utils import raise_value_error
+
+if TYPE_CHECKING:
+    from paradex_py.api.models import SystemConfig
 
 __all__ = ["ParadexL2"]
 
@@ -29,6 +33,10 @@ class ParadexL2(_ClientBase):
         ws_timeout (int, optional): WebSocket read timeout in seconds. Defaults to None (uses default).
         ws_enabled (bool, optional): Whether to create a WebSocket client. Defaults to True.
             Set to False for REST-only use cases to avoid starting background connection machinery.
+        config (SystemConfig, optional): Pre-fetched system configuration. If provided,
+            it is used as-is and the ``GET /system/config`` request is skipped. Callers
+            that build many clients can fetch it once and reuse it. Defaults to None
+            (fetched from the API).
 
     Examples:
         >>> from paradex_py import ParadexL2
@@ -49,6 +57,7 @@ class ParadexL2(_ClientBase):
         ws_timeout: int | None = None,
         ws_enabled: bool = True,
         ws_sbe_enabled: bool = False,
+        config: "SystemConfig | None" = None,
     ):
         _validate_env(env, "ParadexL2")
 
@@ -72,7 +81,10 @@ class ParadexL2(_ClientBase):
             if ws_enabled
             else None
         )
-        self.config = self.api_client.fetch_system_config()
+        if config is not None:
+            self.config = config
+        else:
+            self.config = self.api_client.fetch_system_config()
 
         self.account = SubkeyAccount(
             config=self.config,

--- a/tests/api/test_injection_points.py
+++ b/tests/api/test_injection_points.py
@@ -542,3 +542,43 @@ class TestSimulatorUseCases:
 
         await paradex.ws_client.pump_once()
         assert len(received_messages) == 1
+
+
+class TestParadexL2ConfigInjection:
+    """ParadexL2 accepts a pre-fetched SystemConfig to skip the fetch."""
+
+    @patch("paradex_py.paradex_l2.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_l2.SubkeyAccount")
+    @patch("paradex_py.paradex_l2.ParadexApiClient")
+    def test_injected_config_skips_fetch(self, mock_api_cls, mock_account_cls, mock_ws_cls):
+        from paradex_py.paradex_l2 import ParadexL2
+
+        sentinel_config = object()
+        mock_api = mock_api_cls.return_value
+        client = ParadexL2(
+            env=TESTNET,
+            l2_private_key="0x1",
+            l2_address="0x2",
+            ws_enabled=False,
+            config=sentinel_config,
+        )
+        assert client.config is sentinel_config
+        mock_api.fetch_system_config.assert_not_called()
+        _, account_kwargs = mock_account_cls.call_args
+        assert account_kwargs["config"] is sentinel_config
+
+    @patch("paradex_py.paradex_l2.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_l2.SubkeyAccount")
+    @patch("paradex_py.paradex_l2.ParadexApiClient")
+    def test_fetches_config_when_not_provided(self, mock_api_cls, mock_account_cls, mock_ws_cls):
+        from paradex_py.paradex_l2 import ParadexL2
+
+        mock_api = mock_api_cls.return_value
+        client = ParadexL2(
+            env=TESTNET,
+            l2_private_key="0x1",
+            l2_address="0x2",
+            ws_enabled=False,
+        )
+        mock_api.fetch_system_config.assert_called_once()
+        assert client.config is mock_api.fetch_system_config.return_value


### PR DESCRIPTION
Support system config as input for ParadexSubkey, consistently to
ParadexL2 constructor.
It allows prefetching config once when building multiple clients