### PR TITLE
EVM vault operator sessions: auth-as-operator and operator address derivation

### DIFF
--- a/paradex_py/account/evm_account.py
+++ b/paradex_py/account/evm_account.py
@@ -39,6 +39,13 @@ class EvmAccount:
         env (Environment): Environment (used to select the SIWE domain).
         evm_address (str): Ethereum address (checksummed or lowercase hex).
         evm_private_key (str): Ethereum private key (hex string with 0x prefix).
+        l2_address (str, optional): Pre-resolved L2 address; derived from the EVM
+            address when omitted.
+        is_onboarded (bool, optional): Cached onboarding state; ``True`` skips the
+            auto-onboarding path.
+        is_vault_operator (bool, optional): The session targets an EVM vault
+            operator sub-account (requires ``l2_address``). Operators are onboarded
+            by vault creation — ``onboarding_headers()`` raises for them.
 
     Examples:
         >>> from paradex_py.account.evm_account import EvmAccount
@@ -61,11 +68,14 @@ class EvmAccount:
         l2_address: str | None = None,
         is_onboarded: bool | None = None,
         rpc_version: str | None = None,
+        is_vault_operator: bool = False,
     ):
         if not evm_address:
             raise_value_error("EvmAccount: EVM address is required")
         if not evm_private_key:
             raise_value_error("EvmAccount: EVM private key is required")
+        if is_vault_operator and l2_address is None:
+            raise_value_error("EvmAccount: a vault operator account requires a pre-resolved l2_address")
 
         self.config = config
         self.env = env
@@ -91,6 +101,7 @@ class EvmAccount:
             # construction and is intended for eventual removal.
             self.l2_address = derive_l2_address_eip191(config, self.evm_address)
         self.is_onboarded = is_onboarded
+        self.is_vault_operator = is_vault_operator
 
         # StarkNet account backed by an EIP-191 signer, so on-chain operations
         # (deposit / withdraw / transfer / guardian) can be signed with the
@@ -207,6 +218,13 @@ class EvmAccount:
     # ------------------------------------------------------------------
 
     def onboarding_headers(self) -> dict:
+        if self.is_vault_operator:
+            raise_value_error(
+                "EvmAccount: vault operator accounts are onboarded by vault creation "
+                "(POST /vaults with operator_signer_type=eip191); they cannot be "
+                "onboarded via POST /v2/onboarding. If auth failed with NOT_ONBOARDED, "
+                "the operator does not exist yet — create the vault first."
+            )
         siwe = self._build_siwe_onboarding()
         return {
             "PARADEX-STARKNET-ACCOUNT": hex(self.l2_address),

--- a/paradex_py/account/utils.py
+++ b/paradex_py/account/utils.py
@@ -137,6 +137,40 @@ def derive_l2_address_eip191(config: "SystemConfig", evm_address: str) -> int:
     )
 
 
+# Domain tag for EVM child-account salt derivation, sn_keccak of the exact
+# preimage "paradex.child.vault_operator". Mirrors the Paradex backend's
+# vault-operator kind tag; the tag is part of the on-chain deployment salt and
+# must never change.
+VAULT_OPERATOR_CHILD_KIND_TAG = get_selector_from_name("paradex.child.vault_operator")
+
+
+def derive_vault_operator_l2_address_eip191(config: "SystemConfig", evm_address: str, operator_index: int) -> int:
+    """Compute the L2 address of an EVM-owned vault operator sub-account.
+
+    Mirrors the server-side derivation (``ComputeEvmVaultOperatorAddress``):
+    same Argent v0.5.0 class hash and constructor calldata as the owner's main
+    EVM account (owner = Eip191(evm_address), guardian = None); only the UDC
+    salt differs::
+
+        salt = pedersen(pedersen(owner_l2_address, VAULT_OPERATOR_CHILD_KIND_TAG), operator_index)
+
+    The same address is returned by ``GET /onboarding?account_signer_type=eip191
+    &eth_address=..&vault_operator_index=N`` — prefer that on environments where
+    the class hash may rotate.
+    """
+    if operator_index < 0:
+        raise_value_error(f"operator_index must be non-negative, got {operator_index}")
+    owner_l2 = derive_l2_address_eip191(config, evm_address)
+    salt = rs_pedersen_hash(rs_pedersen_hash(owner_l2, VAULT_OPERATOR_CHILD_KIND_TAG), operator_index)
+    eth_addr_int = int_from_hex(evm_address)
+    return compute_address(
+        class_hash=int_from_hex(cast(str, config.paraclear_evm_account_hash)),
+        constructor_calldata=[3, eth_addr_int, 1],
+        salt=salt,
+        deployer_address=0,
+    )
+
+
 def resolve_l2_keypair(
     config: "SystemConfig",
     l1_address: str,

--- a/paradex_py/api/api_client.py
+++ b/paradex_py/api/api_client.py
@@ -152,7 +152,7 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
         Public endpoint — no authentication required.
 
         Args:
-            params: Query parameters. Exactly one of two forms:
+            params: Query parameters. One of the following forms:
 
                 Starknet account (``account_signer_type="starknet"``)::
 
@@ -163,6 +163,14 @@ class ParadexApiClient(BlockTradesMixin, HttpClient):
                     {"account_signer_type": "eip191", "eth_address": "0x<evm_address>"}
 
                 Note: ``public_key`` is ignored by the server for EIP-191 accounts.
+
+                EIP-191 accounts additionally accept ``vault_operator_index`` (int) to
+                resolve the address and existence of the N-th EVM vault operator
+                sub-account of that eth key's main account (0-based; requires the
+                server's EVM vault operators feature flag)::
+
+                    {"account_signer_type": "eip191", "eth_address": "0x<evm_address>",
+                     "vault_operator_index": 0}
 
         Returns:
             dict with ``address``, ``exists`` (bool), ``account_signer_type``, and

--- a/paradex_py/paradex_evm.py
+++ b/paradex_py/paradex_evm.py
@@ -173,12 +173,12 @@ class ParadexEvm(_ClientBase):
                         "pre-feature deployment)"
                     )
             else:
+                if vault_operator_index is None:
+                    # Unreachable: is_vault_operator with no address implies an
+                    # index. The explicit check narrows the type for ty.
+                    raise_value_error("ParadexEvm: vault operator session requires an index")
                 l2_address_hex = hex(
-                    derive_vault_operator_l2_address_eip191(
-                        self.config,
-                        checksum_address,
-                        vault_operator_index,  # type: ignore[arg-type]
-                    )
+                    derive_vault_operator_l2_address_eip191(self.config, checksum_address, vault_operator_index)
                 )
             is_onboarded = True
         elif server_derive_address:

--- a/paradex_py/paradex_evm.py
+++ b/paradex_py/paradex_evm.py
@@ -138,49 +138,14 @@ class ParadexEvm(_ClientBase):
         # what both the ``/onboarding`` endpoint and the local derivation helper expect.
         checksum_address = EthAccount.from_key(evm_private_key).address
         is_vault_operator = vault_operator_address is not None or vault_operator_index is not None
-        is_onboarded: bool | None = None
         if is_vault_operator:
-            # Operator sessions authenticate as the operator's L2 address while
-            # signing SIWE with the owner's key. Operators are onboarded by vault
-            # creation, never by POST /v2/onboarding, so is_onboarded=True skips
-            # the auto-onboarding path and goes straight to POST /v2/auth.
-            if vault_operator_address is not None:
-                l2_address_hex = vault_operator_address
-            elif server_derive_address:
-                info = self.api_client.fetch_onboarding(
-                    {
-                        "account_signer_type": "eip191",
-                        "eth_address": checksum_address,
-                        "vault_operator_index": vault_operator_index,
-                    }
-                )
-                l2_address_hex = info["address"]
-                if info.get("exists") is False:
-                    raise_value_error(
-                        f"ParadexEvm: vault operator index {vault_operator_index} "
-                        f"({l2_address_hex}) does not exist yet — operators are created "
-                        "by vault creation with operator_signer_type=eip191"
-                    )
-                # A server that predates EVM vault operators ignores the unknown
-                # vault_operator_index query param and answers for the OWNER's
-                # main account. Never let an "operator" session silently target
-                # the main account.
-                if int(l2_address_hex, 16) == derive_l2_address_eip191(self.config, checksum_address):
-                    raise_value_error(
-                        "ParadexEvm: GET /onboarding returned the owner's main account "
-                        f"for vault_operator_index={vault_operator_index} — this server "
-                        "does not support EVM vault operators (feature flag off or "
-                        "pre-feature deployment)"
-                    )
-            else:
-                if vault_operator_index is None:
-                    # Unreachable: is_vault_operator with no address implies an
-                    # index. The explicit check narrows the type for ty.
-                    raise_value_error("ParadexEvm: vault operator session requires an index")
-                l2_address_hex = hex(
-                    derive_vault_operator_l2_address_eip191(self.config, checksum_address, vault_operator_index)
-                )
-            is_onboarded = True
+            l2_address_hex = self._resolve_operator_address(
+                checksum_address, vault_operator_address, vault_operator_index, server_derive_address
+            )
+            # Operators are onboarded by vault creation, never by POST
+            # /v2/onboarding, so is_onboarded=True skips the auto-onboarding
+            # path and goes straight to POST /v2/auth.
+            is_onboarded: bool | None = True
         elif server_derive_address:
             info = self.api_client.fetch_onboarding(
                 {
@@ -193,6 +158,7 @@ class ParadexEvm(_ClientBase):
             is_onboarded = bool(exists) if exists is not None else None
         else:
             l2_address_hex = hex(derive_l2_address_eip191(self.config, checksum_address))
+            is_onboarded = None
 
         self.account = EvmAccount(
             config=self.config,
@@ -205,6 +171,56 @@ class ParadexEvm(_ClientBase):
         )
 
         self.api_client.init_account_evm(self.account)
+
+    def _resolve_operator_address(
+        self,
+        checksum_address: str,
+        vault_operator_address: str | None,
+        vault_operator_index: int | None,
+        server_derive_address: bool,
+    ) -> str:
+        """Resolve the L2 address of the vault operator this session targets.
+
+        Operator sessions authenticate as the operator's L2 address while
+        signing SIWE with the owner's key. The address comes from (in order):
+        the explicit ``vault_operator_address``, the server
+        (``GET /onboarding?vault_operator_index=N``) when
+        ``server_derive_address`` is on, or local derivation.
+        """
+        if vault_operator_address is not None:
+            return vault_operator_address
+        if vault_operator_index is None:
+            # Unreachable from __init__ (operator sessions imply an address or
+            # an index); the explicit check narrows the type for ty.
+            raise_value_error("ParadexEvm: vault operator session requires an address or index")
+        if not server_derive_address:
+            return hex(derive_vault_operator_l2_address_eip191(self.config, checksum_address, vault_operator_index))
+        info = self.api_client.fetch_onboarding(
+            {
+                "account_signer_type": "eip191",
+                "eth_address": checksum_address,
+                "vault_operator_index": vault_operator_index,
+            }
+        )
+        l2_address_hex: str = info["address"]
+        if info.get("exists") is False:
+            raise_value_error(
+                f"ParadexEvm: vault operator index {vault_operator_index} "
+                f"({l2_address_hex}) does not exist yet — operators are created "
+                "by vault creation with operator_signer_type=eip191"
+            )
+        # A server that predates EVM vault operators ignores the unknown
+        # vault_operator_index query param and answers for the OWNER's main
+        # account. Never let an "operator" session silently target the main
+        # account.
+        if int(l2_address_hex, 16) == derive_l2_address_eip191(self.config, checksum_address):
+            raise_value_error(
+                "ParadexEvm: GET /onboarding returned the owner's main account "
+                f"for vault_operator_index={vault_operator_index} — this server "
+                "does not support EVM vault operators (feature flag off or "
+                "pre-feature deployment)"
+            )
+        return l2_address_hex
 
     @property
     def auth_level(self) -> AuthLevel:

--- a/paradex_py/paradex_evm.py
+++ b/paradex_py/paradex_evm.py
@@ -7,7 +7,10 @@ from starknet_py.net.signer.key_pair import KeyPair
 
 from paradex_py._client_base import _ClientBase
 from paradex_py.account.evm_account import EvmAccount
-from paradex_py.account.utils import derive_l2_address_eip191
+from paradex_py.account.utils import (
+    derive_l2_address_eip191,
+    derive_vault_operator_l2_address_eip191,
+)
 from paradex_py.api.api_client import ParadexApiClient
 from paradex_py.api.ws_client import ParadexWebsocketClient
 from paradex_py.auth_level import AuthLevel
@@ -43,6 +46,21 @@ class ParadexEvm(_ClientBase):
             ``paraclear_evm_account_hash``. Also caches the ``exists`` flag so
             ``POST /v2/onboarding`` is skipped when the account is already onboarded. Defaults
             to False (local derivation path unchanged).
+        vault_operator_address (str, optional): Authenticate *as* this EVM vault
+            operator sub-account instead of the key's own main account. The SIWE
+            message is still signed by ``evm_private_key`` (operators have no key of
+            their own), but the session targets the operator: the JWT's ``sub`` is the
+            operator address, so subkeys registered in this session belong to the
+            operator and :meth:`create_trading_subkey` returns a client that trades
+            the vault. The operator must already exist (it is created by vault
+            creation with ``operator_signer_type=eip191``). Mutually exclusive with
+            ``vault_operator_index``.
+        vault_operator_index (int, optional): Like ``vault_operator_address``, but
+            resolves the operator's address from its index: server-side via
+            ``GET /onboarding?vault_operator_index=N`` when
+            ``server_derive_address=True``, locally otherwise. Index N is the N-th
+            eip191 vault operator of this EVM key's main account (0-based, allocated
+            at vault creation). Mutually exclusive with ``vault_operator_address``.
 
     Examples:
         >>> from paradex_py import ParadexEvm
@@ -60,6 +78,15 @@ class ParadexEvm(_ClientBase):
         ...     "public_key": "0x...",
         ...     "state": "active",
         ... })
+        >>> # Trade a vault as its EVM operator (owner key, operator target)
+        >>> operator = ParadexEvm(
+        ...     env=Environment.TESTNET,
+        ...     evm_address="0x...",
+        ...     evm_private_key="0x...",
+        ...     vault_operator_index=0,
+        ... )
+        >>> subkey = operator.create_trading_subkey()
+        >>> subkey.api_client.submit_order(order=buy_order)
     """
 
     def __init__(
@@ -72,6 +99,8 @@ class ParadexEvm(_ClientBase):
         ws_enabled: bool = True,
         ws_sbe_enabled: bool = False,
         server_derive_address: bool = False,
+        vault_operator_address: str | None = None,
+        vault_operator_index: int | None = None,
     ):
         _validate_env(env, "ParadexEvm")
 
@@ -79,6 +108,10 @@ class ParadexEvm(_ClientBase):
             raise_value_error(f"ParadexEvm: EVM address is required, got {evm_address!r}")
         if not evm_private_key:
             raise_value_error("ParadexEvm: EVM private key is required")
+        if vault_operator_address is not None and vault_operator_index is not None:
+            raise_value_error(
+                "ParadexEvm: vault_operator_address and vault_operator_index are mutually exclusive — pass at most one"
+            )
 
         self.env = env
         self.logger: logging.Logger = logger or logging.getLogger(__name__)
@@ -104,15 +137,58 @@ class ParadexEvm(_ClientBase):
         # `EthAccount.from_key(...)` normalises the address to checksum format, which is
         # what both the ``/onboarding`` endpoint and the local derivation helper expect.
         checksum_address = EthAccount.from_key(evm_private_key).address
+        is_vault_operator = vault_operator_address is not None or vault_operator_index is not None
         is_onboarded: bool | None = None
-        if server_derive_address:
+        if is_vault_operator:
+            # Operator sessions authenticate as the operator's L2 address while
+            # signing SIWE with the owner's key. Operators are onboarded by vault
+            # creation, never by POST /v2/onboarding, so is_onboarded=True skips
+            # the auto-onboarding path and goes straight to POST /v2/auth.
+            if vault_operator_address is not None:
+                l2_address_hex = vault_operator_address
+            elif server_derive_address:
+                info = self.api_client.fetch_onboarding(
+                    {
+                        "account_signer_type": "eip191",
+                        "eth_address": checksum_address,
+                        "vault_operator_index": vault_operator_index,
+                    }
+                )
+                l2_address_hex = info["address"]
+                if info.get("exists") is False:
+                    raise_value_error(
+                        f"ParadexEvm: vault operator index {vault_operator_index} "
+                        f"({l2_address_hex}) does not exist yet — operators are created "
+                        "by vault creation with operator_signer_type=eip191"
+                    )
+                # A server that predates EVM vault operators ignores the unknown
+                # vault_operator_index query param and answers for the OWNER's
+                # main account. Never let an "operator" session silently target
+                # the main account.
+                if int(l2_address_hex, 16) == derive_l2_address_eip191(self.config, checksum_address):
+                    raise_value_error(
+                        "ParadexEvm: GET /onboarding returned the owner's main account "
+                        f"for vault_operator_index={vault_operator_index} — this server "
+                        "does not support EVM vault operators (feature flag off or "
+                        "pre-feature deployment)"
+                    )
+            else:
+                l2_address_hex = hex(
+                    derive_vault_operator_l2_address_eip191(
+                        self.config,
+                        checksum_address,
+                        vault_operator_index,  # type: ignore[arg-type]
+                    )
+                )
+            is_onboarded = True
+        elif server_derive_address:
             info = self.api_client.fetch_onboarding(
                 {
                     "account_signer_type": "eip191",
                     "eth_address": checksum_address,
                 }
             )
-            l2_address_hex: str = info["address"]
+            l2_address_hex = info["address"]
             exists = info.get("exists")
             is_onboarded = bool(exists) if exists is not None else None
         else:
@@ -125,6 +201,7 @@ class ParadexEvm(_ClientBase):
             evm_private_key=evm_private_key,
             l2_address=l2_address_hex,
             is_onboarded=is_onboarded,
+            is_vault_operator=is_vault_operator,
         )
 
         self.api_client.init_account_evm(self.account)
@@ -156,7 +233,10 @@ class ParadexEvm(_ClientBase):
         """Cached onboarding state from ``GET /onboarding``.
 
         Returns ``True`` / ``False`` when ``server_derive_address=True`` populated the cache at
-        construction, ``None`` otherwise (local derivation path)."""
+        construction, ``None`` otherwise (local derivation path). Vault operator
+        sessions always report ``True`` — it means "skip auto-onboarding"
+        (operators are onboarded by vault creation), not "existence verified";
+        a nonexistent operator fails at auth."""
         return self.account.is_onboarded if self.account is not None else None
 
     def create_trading_subkey(self, name: str = "trading") -> "ParadexSubkey":

--- a/tests/account/test_evm_account_onchain.py
+++ b/tests/account/test_evm_account_onchain.py
@@ -54,3 +54,38 @@ def test_rpc_version_check_skipped_on_client():
     # mark the check done so the first real call doesn't error on it.
     acct = _account()
     assert acct.starknet.client._client._is_spec_version_verified is True
+
+
+def test_vault_operator_requires_preresolved_l2_address():
+    config = MockApiClient().fetch_system_config()
+    import pytest
+
+    with pytest.raises(ValueError, match="pre-resolved l2_address"):
+        EvmAccount(
+            config=config,
+            env="testnet",
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            is_vault_operator=True,
+        )
+
+
+def test_vault_operator_onboarding_headers_raises():
+    # Operators are onboarded by vault creation, never POST /v2/onboarding —
+    # attempting it must fail loudly instead of onboarding a phantom account.
+    config = MockApiClient().fetch_system_config()
+    import pytest
+
+    acct = EvmAccount(
+        config=config,
+        env="testnet",
+        evm_address=EVM_ADDR,
+        evm_private_key=EVM_KEY,
+        l2_address=L2_ADDR,
+        is_vault_operator=True,
+    )
+    with pytest.raises(ValueError, match="onboarded by vault creation"):
+        acct.onboarding_headers()
+    # Auth headers remain available — that's the operator session's whole point.
+    headers = acct.auth_headers()
+    assert headers["PARADEX-STARKNET-ACCOUNT"] == hex(int(L2_ADDR, 16))

--- a/tests/account/test_vault_operator_derivation.py
+++ b/tests/account/test_vault_operator_derivation.py
@@ -1,0 +1,56 @@
+"""Tests for EVM vault-operator L2 address derivation.
+
+The reference vector below was verified end-to-end against testnet on
+2026-07-13: the operator address was returned by
+``GET /onboarding?...&vault_operator_index=0``, the vault was created with
+``operator_signer_type=eip191``, and the operator contract was confirmed
+deployed at that address on-chain (``starknet_getClassHashAt`` returned the
+expected class hash). A derivation change that breaks this vector breaks
+address compatibility with the backend.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from paradex_py.account.utils import (
+    VAULT_OPERATOR_CHILD_KIND_TAG,
+    derive_l2_address_eip191,
+    derive_vault_operator_l2_address_eip191,
+)
+
+# Testnet Argent v0.5.0 EVM account class hash at the time the vector was taken.
+CONFIG = SimpleNamespace(
+    paraclear_evm_account_hash="0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2"
+)
+ETH_ADDRESS = "0x53A3ca2Fcf33f82de111B5E3Ce4d0B76C8f6f938"
+OWNER_L2 = 0x26EA01C2D5CCB55F9CCE7F715296C4BB7108E3E2C9DA2371FE8E5462B0B81EF
+OPERATOR_IDX0 = 0x3B9F56A4A522916321F60037E1A00E177A9166B9B1289E19A8CF6CB76EDCAE8
+
+
+def test_kind_tag_is_pinned():
+    # sn_keccak("paradex.child.vault_operator") — mirrors VaultOperatorChildKindTag
+    # in the backend. The tag feeds the on-chain deployment salt: it must never
+    # change once any operator is deployed with it.
+    assert VAULT_OPERATOR_CHILD_KIND_TAG == 0x19B452917784423BFEE0CAEE1D05E35F32F4874FDCF99C43B3F9BF197D42E60
+
+
+def test_owner_derivation_matches_testnet_vector():
+    assert derive_l2_address_eip191(CONFIG, ETH_ADDRESS) == OWNER_L2
+
+
+def test_operator_derivation_matches_testnet_vector():
+    assert derive_vault_operator_l2_address_eip191(CONFIG, ETH_ADDRESS, 0) == OPERATOR_IDX0
+
+
+def test_operator_addresses_distinct_per_index_and_from_owner():
+    idx0 = derive_vault_operator_l2_address_eip191(CONFIG, ETH_ADDRESS, 0)
+    idx1 = derive_vault_operator_l2_address_eip191(CONFIG, ETH_ADDRESS, 1)
+    owner = derive_l2_address_eip191(CONFIG, ETH_ADDRESS)
+    assert idx0 != idx1
+    assert owner not in (idx0, idx1)
+
+
+def test_negative_operator_index_raises():
+    with pytest.raises(ValueError):
+        derive_vault_operator_l2_address_eip191(CONFIG, ETH_ADDRESS, -1)

--- a/tests/test_auth_modes.py
+++ b/tests/test_auth_modes.py
@@ -827,9 +827,7 @@ class TestParadexEvm:
     @patch("paradex_py.paradex_evm.EvmAccount")
     @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
     @patch("paradex_py.paradex_evm.ParadexApiClient")
-    def test_vault_operator_index_server_derivation(
-        self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive
-    ):
+    def test_vault_operator_index_server_derivation(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive):
         """server_derive_address=True resolves the operator address via GET /onboarding
         with the vault_operator_index param. (derive_l2_address_eip191 is patched to a
         value distinct from the server's answer — the main-account-fallback guard

--- a/tests/test_auth_modes.py
+++ b/tests/test_auth_modes.py
@@ -604,6 +604,7 @@ class TestParadexEvm:
             evm_private_key=EVM_KEY,
             l2_address=hex(0xABC),
             is_onboarded=None,
+            is_vault_operator=False,
         )
         mock_api.init_account_evm.assert_called_once_with(MockEvmAccount.return_value)
         assert p.config is MOCK_SYSTEM_CONFIG
@@ -762,7 +763,170 @@ class TestParadexEvm:
             evm_private_key=EVM_KEY,
             l2_address="0xabc123",
             is_onboarded=True,
+            is_vault_operator=False,
         )
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_vault_operator_address_targets_operator(self, MockApiClient, MockWsClient, MockEvmAccount):
+        """An explicit operator address becomes the session target: EvmAccount gets it as
+        l2_address with is_vault_operator=True and is_onboarded=True (operators are
+        onboarded by vault creation, so the auto-onboarding path must be skipped)."""
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+
+        ParadexEvm(
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            vault_operator_address="0xfeed",
+        )
+
+        mock_api.fetch_onboarding.assert_not_called()
+        MockEvmAccount.assert_called_once_with(
+            config=MOCK_SYSTEM_CONFIG,
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            l2_address="0xfeed",
+            is_onboarded=True,
+            is_vault_operator=True,
+        )
+
+    @patch("paradex_py.paradex_evm.derive_vault_operator_l2_address_eip191", return_value=0xDEF)
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_vault_operator_index_local_derivation(self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive_op):
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+
+        ParadexEvm(
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            vault_operator_index=2,
+        )
+
+        from eth_account import Account as _EthAccount
+
+        checksum = _EthAccount.from_key(EVM_KEY).address
+        mock_derive_op.assert_called_once_with(MOCK_SYSTEM_CONFIG, checksum, 2)
+        MockEvmAccount.assert_called_once_with(
+            config=MOCK_SYSTEM_CONFIG,
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            l2_address=hex(0xDEF),
+            is_onboarded=True,
+            is_vault_operator=True,
+        )
+
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_vault_operator_index_server_derivation(
+        self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive
+    ):
+        """server_derive_address=True resolves the operator address via GET /onboarding
+        with the vault_operator_index param. (derive_l2_address_eip191 is patched to a
+        value distinct from the server's answer — the main-account-fallback guard
+        compares the two.)"""
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        mock_api.fetch_onboarding.return_value = {
+            "account_signer_type": "eip191",
+            "address": "0xfacade",
+            "exists": True,
+        }
+
+        ParadexEvm(
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            server_derive_address=True,
+            vault_operator_index=0,
+        )
+
+        params = mock_api.fetch_onboarding.call_args[0][0]
+        assert params["account_signer_type"] == "eip191"
+        assert params["vault_operator_index"] == 0
+        MockEvmAccount.assert_called_once_with(
+            config=MOCK_SYSTEM_CONFIG,
+            env=TESTNET,
+            evm_address=EVM_ADDR,
+            evm_private_key=EVM_KEY,
+            l2_address="0xfacade",
+            is_onboarded=True,
+            is_vault_operator=True,
+        )
+
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_vault_operator_index_server_not_exists_raises(self, MockApiClient, MockWsClient, MockEvmAccount):
+        """A server probe that reports exists=False fails fast: the operator is only
+        created by vault creation, so authenticating as it can never succeed."""
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        mock_api.fetch_onboarding.return_value = {
+            "account_signer_type": "eip191",
+            "address": "0xfacade",
+            "exists": False,
+        }
+
+        with pytest.raises(ValueError, match="does not exist yet"):
+            ParadexEvm(
+                env=TESTNET,
+                evm_address=EVM_ADDR,
+                evm_private_key=EVM_KEY,
+                server_derive_address=True,
+                vault_operator_index=1,
+            )
+        MockEvmAccount.assert_not_called()
+
+    @patch("paradex_py.paradex_evm.derive_l2_address_eip191", return_value=0xABC)
+    @patch("paradex_py.paradex_evm.EvmAccount")
+    @patch("paradex_py.paradex_evm.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_vault_operator_index_server_main_account_fallback_raises(
+        self, MockApiClient, MockWsClient, MockEvmAccount, mock_derive
+    ):
+        """A server that predates EVM vault operators ignores the unknown
+        vault_operator_index param and answers for the owner's MAIN account. The
+        client must refuse rather than silently run an "operator" session that
+        actually targets the main account."""
+        mock_api = MockApiClient.return_value
+        mock_api.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        mock_api.fetch_onboarding.return_value = {
+            "account_signer_type": "eip191",
+            "address": hex(0xABC),  # == the owner's main account address
+            "exists": True,
+        }
+
+        with pytest.raises(ValueError, match="does not support EVM vault operators"):
+            ParadexEvm(
+                env=TESTNET,
+                evm_address=EVM_ADDR,
+                evm_private_key=EVM_KEY,
+                server_derive_address=True,
+                vault_operator_index=0,
+            )
+        MockEvmAccount.assert_not_called()
+
+    @patch("paradex_py.paradex_evm.ParadexApiClient")
+    def test_vault_operator_address_and_index_mutually_exclusive(self, MockApiClient):
+        MockApiClient.return_value.fetch_system_config.return_value = MOCK_SYSTEM_CONFIG
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            ParadexEvm(
+                env=TESTNET,
+                evm_address=EVM_ADDR,
+                evm_private_key=EVM_KEY,
+                vault_operator_address="0xfeed",
+                vault_operator_index=0,
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `ParadexEvm(vault_operator_address=…)` / `ParadexEvm(vault_operator_index=…)`: authenticate **as** an EVM vault operator sub-account — SIWE is still signed by the owner's eth key, but the session targets the operator, so `create_trading_subkey()` returns a client that trades the vault. This is the missing piece for API traders operating EVM-owned vaults (`operator_signer_type=eip191`).
- `derive_vault_operator_l2_address_eip191()`: local operator address derivation with the domain-tagged salt `pedersen(pedersen(ownerL2, sn_keccak("paradex.child.vault_operator")), index)`, matching the server; index resolution is also supported server-side via `GET /onboarding?vault_operator_index=N` (used when `server_derive_address=True`).
- Safety: operator sessions never auto-onboard (operators are created by vault creation); `onboarding_headers()` raises for operator accounts; a server probe returning `exists=false` fails fast; and if a pre-feature server ignores the `vault_operator_index` param and answers for the owner's **main** account, the client refuses instead of silently running an "operator" session against the main account.

## Testing
- Derivation pinned against a vector verified on-chain on testnet (operator contract deployed at the derived address; tag felt pinned).
- 6 new `ParadexEvm` tests (explicit address, local index, server index, not-exists, main-account-fallback guard, mutual exclusion), 2 `EvmAccount` guard tests.
- Full suite: 508 passed; ruff clean.

## Usage
```python
operator = ParadexEvm(env=TESTNET, evm_address="0x…", evm_private_key="0x…",
                      vault_operator_index=0)
subkey = operator.create_trading_subkey()
subkey.api_client.submit_order(order=...)
```