### PR TITLE
Support http client injection

### DIFF
--- a/paradex_py/paradex_l2.py
+++ b/paradex_py/paradex_l2.py
@@ -10,6 +10,9 @@ from paradex_py.environment import Environment, _validate_env
 from paradex_py.utils import raise_value_error
 
 if TYPE_CHECKING:
+    import httpx
+
+    from paradex_py.api.http_client import HttpClient
     from paradex_py.api.models import SystemConfig
 
 __all__ = ["ParadexL2"]
@@ -37,6 +40,10 @@ class ParadexL2(_ClientBase):
             it is used as-is and the ``GET /system/config`` request is skipped. Callers
             that build many clients can fetch it once and reuse it. Defaults to None
             (fetched from the API).
+        http_client (httpx.Client | HttpClient, optional): Pre-built HTTP client. Passed
+            straight to ``ParadexApiClient``, so callers that build many clients can share
+            one connection pool and keep its keep-alive settings. Defaults to None (a new
+            ``httpx.Client`` with library defaults).
 
     Examples:
         >>> from paradex_py import ParadexL2
@@ -58,6 +65,7 @@ class ParadexL2(_ClientBase):
         ws_enabled: bool = True,
         ws_sbe_enabled: bool = False,
         config: "SystemConfig | None" = None,
+        http_client: "httpx.Client | HttpClient | None" = None,
     ):
         _validate_env(env, "ParadexL2")
 
@@ -69,7 +77,7 @@ class ParadexL2(_ClientBase):
         self.env = env
         self.logger: logging.Logger = logger or logging.getLogger(__name__)
 
-        self.api_client = ParadexApiClient(env=env, logger=logger)
+        self.api_client = ParadexApiClient(env=env, logger=logger, http_client=http_client)
         self.ws_client: ParadexWebsocketClient | None = (
             ParadexWebsocketClient(
                 env=env,

--- a/paradex_py/paradex_l2.py
+++ b/paradex_py/paradex_l2.py
@@ -10,8 +10,6 @@ from paradex_py.environment import Environment, _validate_env
 from paradex_py.utils import raise_value_error
 
 if TYPE_CHECKING:
-    import httpx
-
     from paradex_py.api.http_client import HttpClient
     from paradex_py.api.models import SystemConfig
 
@@ -40,9 +38,9 @@ class ParadexL2(_ClientBase):
             it is used as-is and the ``GET /system/config`` request is skipped. Callers
             that build many clients can fetch it once and reuse it. Defaults to None
             (fetched from the API).
-        http_client (httpx.Client | HttpClient, optional): Pre-built HTTP client. Passed
-            straight to ``ParadexApiClient``, so callers that build many clients can share
-            one connection pool and keep its keep-alive settings. Defaults to None (a new
+        http_client (HttpClient, optional): Pre-built HTTP client. Passed straight to
+            ``ParadexApiClient``, so callers that build many clients can share one
+            connection pool and keep its keep-alive settings. Defaults to None (a new
             ``httpx.Client`` with library defaults).
 
     Examples:
@@ -65,7 +63,7 @@ class ParadexL2(_ClientBase):
         ws_enabled: bool = True,
         ws_sbe_enabled: bool = False,
         config: "SystemConfig | None" = None,
-        http_client: "httpx.Client | HttpClient | None" = None,
+        http_client: "HttpClient | None" = None,
     ):
         _validate_env(env, "ParadexL2")
 

--- a/tests/api/test_injection_points.py
+++ b/tests/api/test_injection_points.py
@@ -598,7 +598,7 @@ class TestParadexL2HttpClientInjection:
     def test_injected_http_client_is_forwarded(self, mock_api_cls, mock_account_cls, mock_ws_cls):
         from paradex_py.paradex_l2 import ParadexL2
 
-        shared = httpx.Client(limits=httpx.Limits(keepalive_expiry=600.0))
+        shared = HttpClient(http_client=httpx.Client(limits=httpx.Limits(keepalive_expiry=600.0)))
         ParadexL2(
             env=TESTNET,
             l2_private_key="0x1",

--- a/tests/api/test_injection_points.py
+++ b/tests/api/test_injection_points.py
@@ -582,3 +582,46 @@ class TestParadexL2ConfigInjection:
         )
         mock_api.fetch_system_config.assert_called_once()
         assert client.config is mock_api.fetch_system_config.return_value
+
+
+class TestParadexL2HttpClientInjection:
+    """ParadexL2 forwards a pre-built HTTP client to the API client.
+
+    Sharing one client means sharing its connection pool, so callers that
+    build many clients keep the keep-alive settings they configured instead
+    of getting a fresh pool with library defaults each time.
+    """
+
+    @patch("paradex_py.paradex_l2.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_l2.SubkeyAccount")
+    @patch("paradex_py.paradex_l2.ParadexApiClient")
+    def test_injected_http_client_is_forwarded(self, mock_api_cls, mock_account_cls, mock_ws_cls):
+        from paradex_py.paradex_l2 import ParadexL2
+
+        shared = httpx.Client(limits=httpx.Limits(keepalive_expiry=600.0))
+        ParadexL2(
+            env=TESTNET,
+            l2_private_key="0x1",
+            l2_address="0x2",
+            ws_enabled=False,
+            config=MagicMock(),
+            http_client=shared,
+        )
+        _, api_kwargs = mock_api_cls.call_args
+        assert api_kwargs["http_client"] is shared
+
+    @patch("paradex_py.paradex_l2.ParadexWebsocketClient")
+    @patch("paradex_py.paradex_l2.SubkeyAccount")
+    @patch("paradex_py.paradex_l2.ParadexApiClient")
+    def test_no_http_client_keeps_default(self, mock_api_cls, mock_account_cls, mock_ws_cls):
+        from paradex_py.paradex_l2 import ParadexL2
+
+        ParadexL2(
+            env=TESTNET,
+            l2_private_key="0x1",
+            l2_address="0x2",
+            ws_enabled=False,
+            config=MagicMock(),
+        )
+        _, api_kwargs = mock_api_cls.call_args
+        assert api_kwargs["http_client"] is None

--- a/tests/test_auth_modes.py
+++ b/tests/test_auth_modes.py
@@ -69,7 +69,7 @@ class TestParadexL2:
 
         p = ParadexL2(env=TESTNET, l2_private_key=L2_KEY, l2_address=L2_ADDR)
 
-        MockApiClient.assert_called_once_with(env=TESTNET, logger=None)
+        MockApiClient.assert_called_once_with(env=TESTNET, logger=None, http_client=None)
         mock_api.fetch_system_config.assert_called_once()
         MockSubkeyAccount.assert_called_once_with(config=MOCK_SYSTEM_CONFIG, l2_private_key=L2_KEY, l2_address=L2_ADDR)
         mock_api.init_account.assert_called_once_with(MockSubkeyAccount.return_value)


### PR DESCRIPTION
`ParadexApiClient` already accepts a pre-built HTTP client, but `ParadexL2`
builds its own, so a caller that creates many clients cannot share a
connection pool: each client gets a fresh `httpx.Client` with library
defaults, whose keep-alive expiry is 5 seconds. Forwarding `http_client=`
lets the caller supply the client and keep the pool and the keep-alive
window it configured. Omitting it keeps today's behaviour, a new client
per instance.

Same shape as the existing `config=` passthrough: the argument is handed to
`ParadexApiClient` untouched and defaults to None. Worth knowing for callers
that want one pool across several accounts: the account's JWT is stored on
the client's headers, so share a transport and keep one client per account
rather than sharing the client itself.