### PR TITLE
fix: always drop the pending-request entry in _send_request

### DIFF
--- a/paradex_py/api/ws_client.py
+++ b/paradex_py/api/ws_client.py
@@ -958,9 +958,10 @@ class ParadexWebsocketClient:
                 )
             )
             response = await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError:
+        finally:
+            # Every exit drops the entry: a failed send and a cancelled caller left it
+            # behind, and nothing else reclaims it while the connection stays up.
             self._pending_requests.pop(msg_id, None)
-            raise
         if "error" in response:
             raise WsRpcError(response["error"])
         return response.get("result", {})

--- a/tests/api/test_ws_timeout.py
+++ b/tests/api/test_ws_timeout.py
@@ -1,5 +1,9 @@
 """Simple WebSocket timeout tests that don't hang."""
 
+import asyncio
+
+import pytest
+
 from paradex_py import Paradex
 from paradex_py.api.ws_client import ParadexWebsocketClient
 from paradex_py.constants import WS_TIMEOUT
@@ -124,3 +128,41 @@ class TestWebSocketTimeout:
         # Test with zero
         ws_client3 = ParadexWebsocketClient(env=TESTNET, ws_timeout=0)
         assert ws_client3.ws_timeout == 0
+
+
+class TestPendingRequestCleanup:
+    """`_send_request` must not leave entries behind in `_pending_requests`."""
+
+    @pytest.mark.asyncio
+    async def test_pending_cleared_when_send_fails(self):
+        ws_client = ParadexWebsocketClient(env=TESTNET, auto_start_reader=False)
+
+        async def failing_send(_payload):
+            raise ConnectionError
+
+        ws_client._send = failing_send
+
+        with pytest.raises(ConnectionError):
+            await ws_client._send_request("order.create", {})
+
+        assert ws_client._pending_requests == {}
+
+    @pytest.mark.asyncio
+    async def test_pending_cleared_when_caller_cancels(self):
+        # An outer asyncio.wait_for around a request cancels this coroutine while the
+        # connection stays open, so nothing else clears the entry.
+        ws_client = ParadexWebsocketClient(env=TESTNET, auto_start_reader=False)
+
+        async def silent_send(_payload):
+            return None
+
+        ws_client._send = silent_send
+
+        task = asyncio.ensure_future(ws_client._send_request("order.create", {}, timeout=30))
+        while not ws_client._pending_requests:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert ws_client._pending_requests == {}


### PR DESCRIPTION
### The bug

`_send_request` registers a future in `_pending_requests` keyed by message id, but only removes it again on `asyncio.TimeoutError`:

```python
self._pending_requests[msg_id] = future
try:
    await self._send(...)                              # raises -> entry left behind
    response = await asyncio.wait_for(future, timeout=timeout)
except asyncio.TimeoutError:
    self._pending_requests.pop(msg_id, None)           # only this exit cleans up
    raise
```

Two other exits leave the entry behind:

- **`_send` raising** — e.g. the socket closes between the connection check and the write.
- **the caller being cancelled** — which is exactly what an outer `asyncio.wait_for` around an order does when its own deadline fires.

The first case is usually reclaimed: `_cancel_pending_requests` clears the map when the connection drops. **Cancellation is not.** The socket stays open, so nothing clears the entry, and it accumulates for precisely the requests that never receive a response — the timed-out ones. A long-lived client that wraps its order calls in its own timeout leaks one entry per cancellation for the life of the connection.

### The fix

Move the cleanup into a `finally`, which covers every exit and is shorter than the `except`/`raise` it replaces.

Behaviour on the timeout path is unchanged. A late response for an id that has already been dropped falls through the existing `if msg_id in self._pending_requests` check in `_process_message`, which is the same path a timed-out request already takes today.

### Testing

Two tests in `tests/api/test_ws_timeout.py`, covering both leaking exits:

- `test_pending_cleared_when_send_fails`
- `test_pending_cleared_when_caller_cancels`

On `main` with these tests, both fail — the cancellation case leaves `{1: <Future cancelled>}` in the map:

```
FAILED tests/api/test_ws_timeout.py::TestPendingRequestCleanup::test_pending_cleared_when_send_fails
FAILED tests/api/test_ws_timeout.py::TestPendingRequestCleanup::test_pending_cleared_when_caller_cancels
2 failed, 13 passed
```

With the change: `15 passed`.

Full run: `pytest tests/ --ignore=tests/integration` -> **514 passed**. `make check` passes (ruff, ty, deptry, prettier).
